### PR TITLE
docs: remove useless column in field api table

### DIFF
--- a/docs/API/Field_React.md
+++ b/docs/API/Field_React.md
@@ -12,22 +12,22 @@ import {Field} from '@uform/react'
 
 ## API
 
-| 属性名称 | 属性描述 | 属性类型 | 默认值 |  |  |  |  |  |
-| ---- | ---- | ---- | --- | --- | --- | --- | --- | --- |
-| default | 默认值 | any |  |  |  |  |  |  |
-| enum | 枚举值，配置该值在默认情况下会显示Select形态，指定x-component会显示对应的组件形态 | `Array< String | {label:String,value:any}>` | \[] |  |  |  |  |  |
-| maxItems | 最大条目数，只有在type="array"时可以使用 | Number |  |  |  |  |  |  |
-| minItems | 最小条目数，只有在type="array"时可以使用 | Number |  |  |  |  |  |  |
-| name | 字段名称 | Object | {} |  |  |  |  |  |
-| required | 字段是否必填 | Boolean | false |  |  |  |  |  |
-| type | 字段类型 | Object |  |  |  |  |  |  |
-| x-component | 字段UI组件，用于指定该字段应该用什么组件做渲染 | Object | {type:"object",properties:{}} |  |  |  |  |  |
-| x-effect | 副作用事件绑定对象 | `Function(dispatch : Function) : {    [eventName](...arguemtns)}` |  |  |  |  |  |  |
-| x-index | 字段索引顺序 | Number |  |  |  |  |  |  |
-| x-props | 字段UI组件属性，API请参考对应fusion next/ant design组件API | Object | {} |  |  |  |  |  |
-| x-props.editable | 字段是否可编辑 | Boolean | true |  |  |  |  |  |
-| x-render | 字段渲染函数 | `Function(fieldProps : FieldRenderProps){}` |  |  |  |  |  |  |
-| x-rules | 字段校验规则 | Object | Array&lt;String | Object | Function> | String | Function |  |
+| 属性名称 | 属性描述 | 属性类型 | 默认值 |
+| ---- | ---- | ---- | --- |
+| default | 默认值 | any |
+| enum | 枚举值，配置该值在默认情况下会显示Select形态，指定x-component会显示对应的组件形态 | `Array< String | {label:String,value:any}>` | [] |  |
+| maxItems | 最大条目数，只有在type="array"时可以使用 | Number |  |
+| minItems | 最小条目数，只有在type="array"时可以使用 | Number |  |
+| name | 字段名称 | Object | {} |
+| required | 字段是否必填 | Boolean | false |
+| type | 字段类型 | Object |  |
+| x-component | 字段UI组件，用于指定该字段应该用什么组件做渲染 | Object | {type:"object",properties:{}} |
+| x-effect | 副作用事件绑定对象 | `Function(dispatch : Function) : {    [eventName](...arguemtns)}` |  |
+| x-index | 字段索引顺序 | Number |  |
+| x-props | 字段UI组件属性，API请参考对应fusion next/ant design组件API | Object | {} |
+| x-props.editable | 字段是否可编辑 | Boolean | true |
+| x-render | 字段渲染函数 | `Function(fieldProps : FieldRenderProps){}` |  |
+| x-rules | 字段校验规则 | `Object | Arra<String | Object | Function> | String | Function` |  |
 
 ## x-rules详解
 

--- a/docs/API/Field_React.md
+++ b/docs/API/Field_React.md
@@ -27,7 +27,7 @@ import {Field} from '@uform/react'
 | x-props | 字段UI组件属性，API请参考对应fusion next/ant design组件API | Object | {} |
 | x-props.editable | 字段是否可编辑 | Boolean | true |
 | x-render | 字段渲染函数 | `Function(fieldProps : FieldRenderProps){}` |  |
-| x-rules | 字段校验规则 | `Object | Arra<String | Object | Function> | String | Function` |  |
+| x-rules | 字段校验规则 | `Object | Array<String | Object | Function> | String | Function` |  |
 
 ## x-rules详解
 


### PR DESCRIPTION
之前的写法有问题 

`Object | Array <String | Object | Function> | String | Function`

sort-api-table 脚本执行后以为 `| ` 是列的分隔符.
