### PR TITLE
fix(@uform/core): Fixed the value was not cached when the field was hidden

### DIFF
--- a/packages/core/src/field.js
+++ b/packages/core/src/field.js
@@ -208,13 +208,10 @@ export class Field {
   }
 
   unmount() {
-    this.value = undefined
-    this.initialValue = undefined
     this.visible = false
     this.removed = true
     if (!this.context) return
     this.context.deleteIn(this.name)
-    this.context.deleteInitialValues(this.name)
     if (typeof this.value === 'object') {
       this.context.updateChildrenVisible(this, false)
     }


### PR DESCRIPTION
问题：#113

方案：
对于值缓存，策略主要是：
1. 如果是visible为false的是默认会缓存值
2. 如果是显示删除具体值的情况，是不会缓存任何值的，比如Array List场景，点击删除某一行的数据