### PR TITLE
fix(@uform/core): fix initial onFieldChange trverse order

### DIFF
--- a/docs/Examples/antd/Relations.md
+++ b/docs/Examples/antd/Relations.md
@@ -69,6 +69,7 @@ const App = () => {
               state.visible = !fieldState.value
             })
           })
+          
           $('onFieldChange', 'cc').subscribe(fieldState => {
             setFieldState('dd', state => {
               state.visible = !fieldState.value
@@ -85,6 +86,11 @@ const App = () => {
                 state.value = '123333'
                 state.props.enum = ['123333', '333333']
               }
+            })
+          })
+          $('onFieldChange', 'mm').subscribe(fieldState => {
+            setFieldState('ff', state => {
+              state.visible = !fieldState.value
             })
           })
           $('onFieldChange', 'gg')
@@ -153,6 +159,14 @@ const App = () => {
         </FormBlock>
         <FormBlock name="dd" title="Block2">
           <Field name="ee" type="date" title="EE" />
+          <Field
+            name="mm"
+            type="boolean"
+            x-component="radio"
+            default={true}
+            enum={[{ label: '是', value: true }, { label: '否', value: false }]}
+            title="是否隐藏FF"
+          />
           <Field name="ff" type="number" title="FF" />
         </FormBlock>
         <FormBlock name="kk" title="Block3">

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -3,7 +3,7 @@ import {
   setLocale as setValidationLocale,
   setLanguage as setValidationLanguage
 } from '@uform/validator'
-import { caculateSchemaInitialValues, isFn } from './utils'
+import { caculateSchemaInitialValues, isFn, each } from './utils'
 export * from './path'
 export const createForm = ({
   initialValues,
@@ -52,9 +52,13 @@ export const createForm = ({
 
   form.syncUpdate(() => {
     form.triggerEffect('onFormInit', form.publishState())
-    fields.forEach(field => {
-      form.triggerEffect('onFieldChange', field.publishState())
-    })
+    each(
+      fields,
+      field => {
+        form.triggerEffect('onFieldChange', field.publishState())
+      },
+      true
+    )
   })
   return form
 }


### PR DESCRIPTION
因为onFieldChange会提前触发，用于解决默认联动的问题，但是对于默认联动存在一个顺序问题，要理清顺序问题就得理清联动的关系：
- 相邻字段联动
- 父子字段联动
- 相邻跨父联动

然后我们再论证一下每种联动方式是否会受顺序改变而影响
- 相邻字段联动，如果是A,B,C三个字段，A变化会控制B的状态，C变化也会控制B的状态，如果是控制B的相同状态属性，那就会存在一个顺序+优先级问题，应该是C优先级高还是A优先级高，这个我们以正常命令式程序的后序优先的执行策略即可，也比较符合人类思维
- 相邻跨父联动，其实核心还是相邻字段联动，所以还是以后序优先策略来就行了
- 父子字段联动，这个为啥是最后才讲，主要是因为它很复杂，因为父子字段联动是存在隐式联动的，具体就是：
  - 改变父字段的visible状态会影响子字段的visible状态，但改变子字段的visible状态不会影响父字段的visible状态
  - 改变父字段的value/initialValue会影响子字段的value/initialValue，同时改变子字段的value/initialValue也会改变父字段的value/initialValue

总结下来，父子之间的隐式关联在于 **存在性状态+值状态**
然后，我们再继续梳理
   - visible状态是否会受顺序所影响，很明显，如果A是父，B是子，C是B的相邻字段或者跨父相邻字段，如果A与C都对B的visible状态做控制，我们可以看看，如果按照后序优先的原则来处理会不会出现问题，首先我们需要将父子关系打扁，形成一个顺序型结构，打扁后的顺序结构是按照节点遍历的顺序来生成的，相当于子节点是后序节点，参考css层叠样式表的优先级规则，父级规则会被子级规则所覆盖，所以，如果C是A的子节点，那么优先级会比A高，会覆盖A的控制，没问题，如果C是A的先序相邻节点，那么A的优先级高，会覆盖C的控制，同样没问题，如果C是A的后序相邻节点，那么C的优先级高，同样没问题。
   - value/initialValue与visible一样，只是它多了一种竞争控制流，对visible的话，只有**父-->子<---其他** 这样的竞争控制流，但对于value/initialValue，它还有**子--->父<---其他**这样的竞争控制流，总之都是涉及2个以上的字段对一个字段做竞争控制，所以，后序优先的策略在此同样适用

最后，再总结一下，uform存在竞争问题，目前只有在同步初始化联动的时候会存在竞争问题，其余联动都是基于用户交互事件的联动，都是属于异步场景了，对于异步场景的竞争问题，我们有rxjs，可以完备的解决各种异步竞争问题，所以，本次改动，主要的核心策略：后序优先