### PR TITLE
fix(@uform/core): fix setFormState is not work

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -69,13 +69,13 @@ export const publishFormState = state => {
     dirty
   } = state
   return {
-    values,
+    values: clone(values),
     valid,
     invalid,
     errors,
     pristine,
     dirty,
-    initialValues
+    initialValues: clone(initialValues)
   }
 }
 
@@ -108,7 +108,7 @@ export const publishFieldState = state => {
     loading,
     errors: errors.concat(effectErrors),
     pristine,
-    initialValue,
+    initialValue: clone(initialValue),
     name,
     path,
     props,

--- a/packages/react/src/__tests__/actions.spec.js
+++ b/packages/react/src/__tests__/actions.spec.js
@@ -52,3 +52,34 @@ test('createFormActions', async () => {
   expect(queryByText('value of aaa field')).toBeVisible()
   expect(queryByText('value of bbb field')).toBeVisible()
 })
+
+test('setFormState', async () => {
+  const actions = createAsyncFormActions()
+  const TestComponent = () => (
+    <SchemaForm
+      actions={actions}
+      effects={$ => {
+        $('onFieldChange', 'aaa').subscribe(({ value }) => {
+          if (value) {
+            actions.setFormState(state => {
+              state.values.bbb = '123'
+            })
+          }
+        })
+      }}
+    >
+      <Field name="aaa" type="string" />
+      <Field name="bbb" type="string" />
+    </SchemaForm>
+  )
+
+  const { queryByText } = render(<TestComponent />)
+  await sleep(33)
+  expect(queryByText('123')).toBeNull()
+  await actions.setFieldState('aaa',state=>{
+    state.value = 'hello'
+  })
+  await sleep(33)
+  expect(queryByText('hello')).toBeVisible()
+  expect(queryByText('123')).toBeVisible()
+})

--- a/packages/react/src/__tests__/value.spec.js
+++ b/packages/react/src/__tests__/value.spec.js
@@ -74,6 +74,7 @@ test('controlled initialValues', async () => {
   await actions.setFieldState('foo', state => {
     state.value = '321'
   })
+  await sleep(33)
   act(() => {
     outerSetState({ foo: '123' })
   })


### PR DESCRIPTION
```
setFormState(state=>{
  state.values.aa = 123
})
```
这种操作不生效，原因是操作执行前是浅拷贝，导致引用一样，判断相等失败