### PR TITLE
fix(@uform/antd): password add size props

### DIFF
--- a/docs/Examples/antd/Validation.md
+++ b/docs/Examples/antd/Validation.md
@@ -138,9 +138,19 @@ import {
   FormLayout,
   createFormActions
 } from '@uform/antd'
-import { Button } from 'antd'
+import { Button, Icon } from 'antd'
 import Printer from '@uform/printer'
 import 'antd/dist/antd.css'
+
+const PasswordPrefixIcon = (
+  <Icon
+    type="lock"
+    style={{
+      color: 'rgba(0, 0, 0, 0.25)',
+      fontSize: 14
+    }}
+  />
+)
 
 const App = () => (
   <Printer>
@@ -175,7 +185,10 @@ const App = () => (
         type="password"
         name="password"
         title="密码"
-        x-props={{ checkStrength: true }}
+        x-props={{
+          checkStrength: true,
+          prefix: PasswordPrefixIcon,
+        }}
         description={
           <ul>
             <li>1. 长度不小于8个</li>
@@ -188,7 +201,10 @@ const App = () => (
         type="password"
         name="confirm"
         title="确认密码"
-        x-props={{ checkStrength: true }}
+        x-props={{
+          checkStrength: true,
+          prefix: PasswordPrefixIcon,
+        }}
         required
       />
       <FormButtonGroup offset={6}>

--- a/packages/antd/src/fields/password.tsx
+++ b/packages/antd/src/fields/password.tsx
@@ -281,7 +281,6 @@ const Password = styled(
   .ant-input-prefix,
   .ant-input-suffix {
     z-index: 10;
-    right: 20px !important;
     .eye {
       position: absolute;
       max-width: initial;
@@ -298,6 +297,11 @@ const Password = styled(
       }
     }
   }
+
+  .ant-input-suffix {
+    right: 20px !important;
+  }
+
   .ant-input {
     width: 100%;
     position: relative;

--- a/packages/antd/src/fields/password.tsx
+++ b/packages/antd/src/fields/password.tsx
@@ -287,7 +287,7 @@ const Password = styled(
       width: 20px;
       height: 20px;
       top: 50%;
-      left: -5px;
+      left: -10px;
       transform: translate(0, -50%);
       opacity: 0.3;
       cursor: pointer;

--- a/packages/antd/src/fields/password.tsx
+++ b/packages/antd/src/fields/password.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Input } from 'antd'
+import { InputProps } from 'antd/es/input'
 import { connect, registerFormField } from '@uform/react'
+import { mapStyledProps } from '../utils'
 
 var isNum = function(c) {
   return c >= 48 && c <= 57
@@ -152,6 +154,7 @@ const getStrength = val => {
 
 export interface IPasswordProps {
   value: any
+  size: InputProps['size']
   defaultValue: any
   className: string
   // TODO 不知道下面三个是什么东西
@@ -342,4 +345,9 @@ const Password = styled(
   }
 `
 
-registerFormField('password', connect()(Password))
+registerFormField(
+  'password',
+  connect({
+    getProps: mapStyledProps,
+  })(Password)
+)

--- a/packages/antd/src/fields/password.tsx
+++ b/packages/antd/src/fields/password.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Input } from 'antd'
 import { InputProps } from 'antd/es/input'
@@ -152,167 +152,30 @@ const getStrength = val => {
   }
 }
 
-export interface IPasswordProps {
-  value: any
-  size: InputProps['size']
-  defaultValue: any
-  className: string
-  // TODO 不知道下面三个是什么东西
-  checkStrength: any
-  htmlType: any
-  innerAfter: any
-  onChange: (value: any) => void
-}
-
-export interface IPasswordState {
-  value: any
+interface IStrengthProps {
   strength: number
-  eye: boolean
+  className?: string
 }
 
-const Password = styled(
-  class Password extends React.Component<IPasswordProps, IPasswordState> {
-    public state = {
-      value: this.props.value || this.props.defaultValue,
-      strength: 0,
-      eye: false
-    }
-
-    public componentDidUpdate(prevProps) {
-      if (
-        prevProps.value !== this.props.value &&
-        this.props.value !== this.state.value
-      ) {
-        this.setState({
-          value: this.props.value,
-          strength: getStrength(this.props.value)
-        })
-      }
-    }
-
-    public onChangeHandler = e => {
-      const value = e.target.value
-      this.setState(
-        {
-          value,
-          strength: getStrength(value)
-        },
-        () => {
-          if (this.props.onChange) {
-            this.props.onChange(value)
-          }
-        }
-      )
-    }
-
-    public renderStrength() {
-      const { strength } = this.state
-      return (
-        <div className={'password-strength-wrapper'}>
-          <div className={'div-1 div'} />
-          <div className={'div-2 div'} />
-          <div className={'div-3 div'} />
-          <div className={'div-4 div'} />
-          <div
-            className={'password-strength-bar'}
-            style={{
-              clipPath: `polygon(0 0,${strength}% 0,${strength}% 100%,0 100%)`
-            }}
-          />
-        </div>
-      )
-    }
-
-    public switchEye() {
-      return () => {
-        this.setState({
-          eye: !this.state.eye
-        })
-      }
-    }
-
-    public renderEye() {
-      if (!this.state.eye) {
-        return (
-          <img
-            className={'eye'}
-            onClick={this.switchEye()}
-            src={'//img.alicdn.com/tfs/TB1wyXlsVzqK1RjSZFvXXcB7VXa-200-200.svg'}
-          />
-        )
-      } else {
-        return (
-          <img
-            className={'eye'}
-            onClick={this.switchEye()}
-            src={'//img.alicdn.com/tfs/TB1xiXlsVzqK1RjSZFvXXcB7VXa-200-200.svg'}
-          />
-        )
-      }
-    }
-
-    public render() {
-      const {
-        className,
-        checkStrength,
-        value,
-        onChange,
-        htmlType,
-        innerAfter,
-        ...others
-      } = this.props
-
-      return (
-        <div className={className}>
-          <Input
-            type={this.state.eye ? 'text' : 'password'}
-            className={`input-${this.state.eye ? 'text' : 'password'}`}
-            value={this.state.value}
-            onChange={this.onChangeHandler}
-            suffix={this.renderEye()}
-            {...others}
-          />
-          {checkStrength && this.renderStrength()}
-        </div>
-      )
-    }
-  }
+// 校验强度 UI
+const StrengthFC = styled(
+  ({ strength, className }: IStrengthProps) => (
+    <div {...{ className }}>
+      <div className={'password-strength-wrapper'}>
+        <div className={'div-1 div'} />
+        <div className={'div-2 div'} />
+        <div className={'div-3 div'} />
+        <div className={'div-4 div'} />
+        <div
+          className={'password-strength-bar'}
+          style={{
+            clipPath: `polygon(0 0,${strength}% 0,${strength}% 100%,0 100%)`
+          }}
+        />
+      </div>
+    </div>
+  )
 )`
-  .ant-input-prefix,
-  .ant-input-suffix {
-    z-index: 10;
-    .eye {
-      position: absolute;
-      max-width: initial;
-      width: 20px;
-      height: 20px;
-      top: 50%;
-      left: -10px;
-      transform: translate(0, -50%);
-      opacity: 0.3;
-      cursor: pointer;
-      transition: all 0.15s ease-in-out;
-      &:hover {
-        opacity: 0.6;
-      }
-    }
-  }
-
-  .ant-input-suffix {
-    right: 20px !important;
-  }
-
-  .ant-input {
-    width: 100%;
-    position: relative;
-    &.input-password input {
-      font-size: 16px;
-      letter-spacing: 2px;
-    }
-    input {
-      padding-right: 25px;
-    }
-  }
   .password-strength-wrapper {
     background: #e0e0e0;
     margin-bottom: 3px;
@@ -349,9 +212,42 @@ const Password = styled(
   }
 `
 
+export interface IPasswordProps extends Omit<InputProps, 'onChange'> {
+  checkStrength: boolean // 是否启用密码强度校验
+  onChange: (value: InputProps['value']) => void
+}
+
+const PasswordFC = (props: Partial<IPasswordProps>) => {
+  const [strength, setStrength] = useState(0)
+
+  const { checkStrength, ...others } = props
+
+  const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+
+    // 开启才计算
+    checkStrength && setStrength(getStrength(value))
+
+    // 回调
+    props.onChange && props.onChange(value)
+  }
+
+  return (
+    <React.Fragment>
+      <Input.Password
+        {...others}
+        value={props.value || props.defaultValue}
+        onChange={onChangeHandler}
+      />
+
+      {checkStrength && <StrengthFC {...{ strength }} />}
+    </React.Fragment>
+  )
+}
+
 registerFormField(
   'password',
   connect({
     getProps: mapStyledProps,
-  })(Password)
+  })(PasswordFC)
 )


### PR DESCRIPTION
field password 增加 size prop 的接收，跟其他的 field 组件保持一致的表现，不然在外层的 FormLayout 定义了 `size="large"` ，password 会因为没有接收到该值而导致没有预期的表现

调整 `.ant-input-suffix` 的样式，避免在设置了 `prefix` 的时候，导致点击输入的热区被遮挡了一部分，使得点击输入困难

另外 antd 已经新增了 [password-input](https://ant.design/components/input-cn/#components-input-demo-password-input) 组件，是否可以考虑下将 password-field 交由 antd 原生实现？