### PR TITLE
fix(@uform/core/react): Fix intialValues can not one way controlled

### DIFF
--- a/packages/react/src/__tests__/value.spec.js
+++ b/packages/react/src/__tests__/value.spec.js
@@ -20,7 +20,7 @@ registerFormField(
 
 registerFormField(
   'string',
-  connect()(props => <input data-testid="test-input" value="" {...props} />)
+  connect()(props => <input data-testid="test-input" {...props} value={props.value || ''} />)
 )
 
 test('default value', async () => {
@@ -72,6 +72,7 @@ test('controlled initialValues', async () => {
     state.value = '321'
   })
   await actions.reset()
+  await sleep(33)
   expect(getByTestId('value').textContent).toEqual('123')
   await actions.setFieldState('foo', state => {
     state.value = '321'
@@ -87,12 +88,13 @@ test('controlled initialValues', async () => {
 
 test('controlled with hooks by initalValues', async () => {
   const onChangeHandler = jest.fn()
+  const actions = createFormActions()
   const Component = () => {
     const [total, setTotal] = useState(0)
-
     return (
       <div>
         <SchemaForm
+          actions={actions}
           initialValues={{ a3: 123 }}
           effects={$ => {
             $('onFieldChange', 'a3').subscribe(onChangeHandler)
@@ -121,11 +123,26 @@ test('controlled with hooks by initalValues', async () => {
   expect(queryByTestId('outer-result').textContent).toEqual('Total is:333')
   expect(queryByTestId('inner-result').textContent).toEqual('Total is:333')
   expect(onChangeHandler).toHaveBeenCalledTimes(2)
+  await actions.setFieldState('a3',state=>{
+    state.value = '456'
+  })
+  await sleep(33)
+  expect(queryByTestId('test-input').value).toEqual('456')
+  expect(queryByTestId('outer-result').textContent).toEqual('Total is:456')
+  expect(queryByTestId('inner-result').textContent).toEqual('Total is:456')
+  expect(onChangeHandler).toHaveBeenCalledTimes(3)
+  await actions.reset()
+  await sleep(33)
+  expect(queryByTestId('test-input').value).toEqual('123')
+  expect(queryByTestId('outer-result').textContent).toEqual('Total is:456')
+  expect(queryByTestId('inner-result').textContent).toEqual('Total is:456')
+  expect(onChangeHandler).toHaveBeenCalledTimes(3)
 })
 
 
 test('controlled with hooks by value', async () => {
   const onChangeHandler = jest.fn()
+  const actions = createFormActions()
   const Component = () => {
     const [total, setTotal] = useState(0)
 
@@ -133,6 +150,7 @@ test('controlled with hooks by value', async () => {
       <div>
         <SchemaForm
           value={{ a3: 123 }}
+          actions={actions}
           effects={$ => {
             $('onFieldChange', 'a3').subscribe(onChangeHandler)
             $('onFieldChange', 'a3').subscribe(state => {
@@ -160,4 +178,23 @@ test('controlled with hooks by value', async () => {
   expect(queryByTestId('outer-result').textContent).toEqual('Total is:123')
   expect(queryByTestId('inner-result').textContent).toEqual('Total is:123')
   expect(onChangeHandler).toHaveBeenCalledTimes(3)
+  actions.reset()
+  await sleep(33)
+  expect(queryByTestId('outer-result').textContent).toEqual('Total is:123')
+  expect(queryByTestId('inner-result').textContent).toEqual('Total is:123')
+  expect(onChangeHandler).toHaveBeenCalledTimes(3)
+  await actions.setFieldState('a3',state=>{
+    state.value = '456'
+  })
+  await sleep(33)
+  expect(queryByTestId('test-input').value).toEqual('123')
+  expect(queryByTestId('outer-result').textContent).toEqual('Total is:123')
+  expect(queryByTestId('inner-result').textContent).toEqual('Total is:123')
+  expect(onChangeHandler).toHaveBeenCalledTimes(5)
+  await actions.reset()
+  await sleep(33)
+  expect(queryByTestId('test-input').value).toEqual('')
+  expect(queryByTestId('outer-result').textContent).toEqual('Total is:123')
+  expect(queryByTestId('inner-result').textContent).toEqual('Total is:123')
+  expect(onChangeHandler).toHaveBeenCalledTimes(5)
 })

--- a/packages/react/src/__tests__/value.spec.js
+++ b/packages/react/src/__tests__/value.spec.js
@@ -85,7 +85,7 @@ test('controlled initialValues', async () => {
   await sleep(33)
 })
 
-test('controlled with hooks', async () => {
+test('controlled with hooks by initalValues', async () => {
   const onChangeHandler = jest.fn()
   const Component = () => {
     const [total, setTotal] = useState(0)
@@ -121,4 +121,43 @@ test('controlled with hooks', async () => {
   expect(queryByTestId('outer-result').textContent).toEqual('Total is:333')
   expect(queryByTestId('inner-result').textContent).toEqual('Total is:333')
   expect(onChangeHandler).toHaveBeenCalledTimes(2)
+})
+
+
+test('controlled with hooks by value', async () => {
+  const onChangeHandler = jest.fn()
+  const Component = () => {
+    const [total, setTotal] = useState(0)
+
+    return (
+      <div>
+        <SchemaForm
+          value={{ a3: 123 }}
+          effects={$ => {
+            $('onFieldChange', 'a3').subscribe(onChangeHandler)
+            $('onFieldChange', 'a3').subscribe(state => {
+              act(() => {
+                setTotal(state.value)
+              })
+            })
+          }}
+        >
+          <Field type="string" name="a3" />
+          <FormSlot>
+            <div data-testid="inner-result">Total is:{total}</div>
+          </FormSlot>
+        </SchemaForm>
+        <div data-testid="outer-result">Total is:{total}</div>
+      </div>
+    )
+  }
+
+  const { queryByTestId } = render(<Component />)
+  expect(queryByTestId('outer-result').textContent).toEqual('Total is:123')
+  expect(queryByTestId('inner-result').textContent).toEqual('Total is:123')
+  fireEvent.change(queryByTestId('test-input'), { target: { value: '333' } })
+  await sleep(33)
+  expect(queryByTestId('outer-result').textContent).toEqual('Total is:123')
+  expect(queryByTestId('inner-result').textContent).toEqual('Total is:123')
+  expect(onChangeHandler).toHaveBeenCalledTimes(3)
 })

--- a/packages/react/src/__tests__/value.spec.js
+++ b/packages/react/src/__tests__/value.spec.js
@@ -55,7 +55,6 @@ test('controlled initialValues', async () => {
     return (
       <SchemaForm
         actions={actions}
-        onChange={outerSetState}
         initialValues={state}
       >
         <Field name="foo" type="test-string" />

--- a/packages/react/src/state/form.tsx
+++ b/packages/react/src/state/form.tsx
@@ -24,7 +24,6 @@ export const StateForm = createHOC((options, Form) => {
       locale: {}
     }
 
-    private timerId: number
     private unmounted: boolean
     private initialized: boolean
     private lastFormValues: IFormState
@@ -107,20 +106,10 @@ export const StateForm = createHOC((options, Form) => {
 
         lastState = formState
 
-        if (this.initialized) {
-          if (formState.dirty) {
-            clearTimeout(this.timerId)
-            this.timerId = window.setTimeout(() => {
-              clearTimeout(this.timerId)
-              if (this.unmounted) {
-                return
-              }
-              this.setState(formState)
-            }, 60)
-          }
-        } else {
-          // eslint-disable-next-line react/no-direct-mutation-state
-          this.state = formState
+        // eslint-disable-next-line react/no-direct-mutation-state
+        this.state = formState
+
+        if (!this.initialized) {
           this.notify({
             type: 'initialize',
             state: formState
@@ -190,17 +179,13 @@ export const StateForm = createHOC((options, Form) => {
       }
     }
 
-    public shouldComponentUpdate(nextProps) {
-      return !isEqual(nextProps, this.props)
-    }
-
     public componentDidUpdate(prevProps) {
       const { value, editable, initialValues } = this.props
       if (this.form.isDirtyValues(value)) {
         this.form.changeValues(value)
       }
       if (this.form.isDirtyValues(initialValues)) {
-        this.form.initialize({ values: initialValues })
+        this.form.initialize({ values: initialValues, initialValues })
       }
       if (!isEmpty(editable) && !isEqual(editable, prevProps.editable)) {
         this.form.changeEditable(editable)

--- a/packages/react/src/state/form.tsx
+++ b/packages/react/src/state/form.tsx
@@ -27,6 +27,7 @@ export const StateForm = createHOC((options, Form) => {
     private unmounted: boolean
     private initialized: boolean
     private lastFormValues: IFormState
+    private formState: IFormState
     private form: Form
     private unsubscribe: () => void
 
@@ -49,7 +50,7 @@ export const StateForm = createHOC((options, Form) => {
           props.implementActions(this.getActions(form))
         }
       })
-      this.state = {} as IFormState
+      this.formState = {} as IFormState
       this.initialized = true
     }
 
@@ -85,7 +86,7 @@ export const StateForm = createHOC((options, Form) => {
     }
 
     public onFormChangeHandler(props) {
-      let lastState = this.state
+      let lastState = this.formState
       return ({ formState }) => {
         if (this.unmounted) {
           return
@@ -107,7 +108,7 @@ export const StateForm = createHOC((options, Form) => {
         lastState = formState
 
         // eslint-disable-next-line react/no-direct-mutation-state
-        this.state = formState
+        this.formState = formState
 
         if (!this.initialized) {
           this.notify({
@@ -148,19 +149,19 @@ export const StateForm = createHOC((options, Form) => {
           if (promise && promise.then) {
             this.notify({
               type: 'submitting',
-              state: this.state
+              state: this.formState
             })
             promise.then(
               () => {
                 this.notify({
                   type: 'submitted',
-                  state: this.state
+                  state: this.formState
                 })
               },
               error => {
                 this.notify({
                   type: 'submitted',
-                  state: this.state
+                  state: this.formState
                 })
                 throw error
               }

--- a/packages/react/src/state/form.tsx
+++ b/packages/react/src/state/form.tsx
@@ -182,10 +182,15 @@ export const StateForm = createHOC((options, Form) => {
 
     public componentDidUpdate(prevProps) {
       const { value, editable, initialValues } = this.props
-      if (this.form.isDirtyValues(value)) {
+      if (!isEmpty(value) && !isEqual(value, prevProps.value)) {
+        this.form.changeValues(value)
+      } else if (this.form.isDirtyValues(value)) {
         this.form.changeValues(value)
       }
-      if (this.form.isDirtyValues(initialValues)) {
+      if (
+        !isEmpty(initialValues) &&
+        !isEqual(initialValues, prevProps.initialValues)
+      ) {
         this.form.initialize({ values: initialValues, initialValues })
       }
       if (!isEmpty(editable) && !isEqual(editable, prevProps.editable)) {


### PR DESCRIPTION
Fix #190 
修复方式，主要是去掉了StateForm的shouldUpdate判断，这部分是没有必要的，之前加上它是因为在StateForm的onFormChangeHandler方法内执行了setState，onFormChangeHandler触发时机是@uform/core的formNotify方法执行的时候触发，就是说每次字段变化都会触发，其实，form级别的状态，只需要引用是管理即可。

同时，顺带修复了受控改变initialValues的时候，重置可能无法回滚到最新的intialValues状态