### PR TITLE
fix: revert import antd/next on demand

### DIFF
--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -15,7 +15,7 @@
     "npm": ">=3.0.0"
   },
   "scripts": {
-    "build": "node ./build.js"
+    "build": "tsc --declaration"
   },
   "devDependencies": {
     "antd": "^3.14.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -15,7 +15,7 @@
     "npm": ">=3.0.0"
   },
   "scripts": {
-    "build": "node ./build.js"
+    "build": "tsc"
   },
   "peerDependencies": {
     "@alifd/next": "^1.13.1",


### PR DESCRIPTION
因为按需加载antd/next功能有问题，所以暂时还是使用tsc来编译@uform/antd和@uform/next