### PR TITLE
fix(@uform/react): fix schema properties can not update when rerender

### DIFF
--- a/packages/react/src/__tests__/virtualbox.spec.js
+++ b/packages/react/src/__tests__/virtualbox.spec.js
@@ -33,6 +33,7 @@ registerFormField(
   connect()(props => <input {...props} value={props.value || ''} />)
 )
 registerFormField('text', connect()(props => <div>This is Text Component</div>))
+
 FormCard = createVirtualBox('card', ({ children }) => {
   return <div>card content{children}</div>
 })
@@ -87,4 +88,70 @@ test('dynamic node', async () => {
   fireEvent.click(queryByText('Change Editable'))
   await sleep(33)
   expect(queryByText('This is Text Component')).toBeVisible()
+})
+
+test('dynamic schema', async () => {
+  const TestComponent = () => {
+    const [schema, setSchema] = useState({
+      type: 'object',
+      properties: {
+        card: {
+          type: 'object',
+          'x-component': 'card',
+          properties: {
+            aa: {
+              type: 'string',
+              'x-props': {
+                'data-testid': 'aa'
+              }
+            },
+            bb: {
+              type: 'string',
+              'x-props': {
+                'data-testid': 'bb'
+              }
+            }
+          }
+        }
+      }
+    })
+
+    const deleteProperty = () =>
+      setSchema({
+        type: 'object',
+        properties: {
+          card: {
+            type: 'object',
+            'x-component': 'card',
+            properties: {
+              aa: {
+                type: 'string',
+                'x-props': {
+                  'data-testid': 'aa',
+                  disabled: true
+                }
+              }
+              // bb deleted
+            }
+          }
+        }
+      })
+    return (
+      <div>
+        <SchemaForm schema={schema} />
+        <button onClick={deleteProperty}>Delete</button>
+      </div>
+    )
+  }
+
+  const { queryByText, queryByTestId, baseElement } = render(<TestComponent />)
+
+  await sleep(33)
+  act(() => {
+    fireEvent.click(queryByText('Delete'))
+  })
+  await sleep(33)
+  expect(queryByTestId('aa').hasAttribute('disabled')).toBe(true)
+  expect(queryByTestId('aa')).toBeVisible()
+  expect(queryByTestId('bb')).toBeNull()
 })

--- a/packages/react/src/state/field.tsx
+++ b/packages/react/src/state/field.tsx
@@ -116,6 +116,7 @@ const StateField = createHOC((options, Field) => {
         path,
         schemaPath,
         broadcast,
+        schema,
         form,
         locale,
         getSchema
@@ -135,6 +136,12 @@ const StateField = createHOC((options, Field) => {
         : schemaIs(props, 'array')
         ? value || []
         : value
+      //todo: 重置schema children，这里有点恶心，后面重构的时候需要想下怎么重置更合适
+      if (schema.properties) {
+        props.properties = schema.properties
+      } else if (schema.items) {
+        props.items = schema.items
+      }
       return visible === false || display === false ? (
         <React.Fragment />
       ) : (


### PR DESCRIPTION
原因是Field创建之后，它的schema属性就和主schema脱节了，因为它需要作为FieldState的一部分，所以schema与其子节点的关系就无法维系了，只能手动在渲染过程中将其重新建立关联。解决方案不太优雅，但是可以实际解决问题，后续在重构@uform/core的时候需要核心考虑schema关系的管理，因为uform经过这么长的实践探索之后，发现@uform/core其实是一个面向JSON Schema的观察者表单管理模型，所以后续在重构的过程中，@uform/core内部将会拥有完备的schema管理能力

Fix #217 