### PR TITLE
fix(@uform/core): fix value can't be remove in onFieldChange subscriber

### DIFF
--- a/packages/core/src/field.ts
+++ b/packages/core/src/field.ts
@@ -132,6 +132,7 @@ export class Field implements IField {
     }
 
     if (
+      this.pristine &&
       !isEmpty(this.initialValue) &&
       ((isEmpty(this.value) && this.visible) ||
         (this.removed && !this.shownFromParent))

--- a/packages/react/src/__tests__/effects.spec.js
+++ b/packages/react/src/__tests__/effects.spec.js
@@ -7,6 +7,7 @@ import SchemaForm, {
   createFormActions,
   FormPath
 } from '../index'
+import { filter } from 'rxjs/operators'
 import { render, fireEvent, act } from '@testing-library/react'
 
 registerFieldMiddleware(Field => {
@@ -252,4 +253,28 @@ test('setFieldState from buffer', async () => {
   const { queryByTestId } = render(<TestComponent />)
   await sleep(33)
   expect(queryByTestId('test')).toBeVisible()
+})
+
+test('filter first onFieldChange', async () => {
+  const sub1 = jest.fn()
+  const sub2 = jest.fn()
+  const TestComponent = () => {
+    return (
+      <SchemaForm
+        effects={($, { setFieldState }) => {
+          $('onFieldChange', 'aaa')
+            .pipe(filter(state => !state.pristine))
+            .subscribe(sub1)
+          $('onFieldChange', 'aaa').subscribe(sub2)
+        }}
+      >
+        <Field type="string" name="aaa" title="aaa" />
+      </SchemaForm>
+    )
+  }
+
+  render(<TestComponent />)
+  await sleep(33)
+  expect(sub1).toHaveBeenCalledTimes(0)
+  expect(sub2).toHaveBeenCalledTimes(1)
 })

--- a/packages/react/src/__tests__/value.spec.js
+++ b/packages/react/src/__tests__/value.spec.js
@@ -342,3 +342,30 @@ test('submit with number name', async () => {
     }
   })
 })
+
+test('remove initial value by onFieldChange', async () => {
+  const Component = () => {
+    return (
+      <div>
+        <SchemaForm
+          initialValues={{ a1: 'a1' }}
+          effects={($, { setFieldState }) => {
+            $('onFieldChange', 'a2').subscribe(() => {
+              setFieldState('a1', state => {
+                state.value = undefined
+              })
+            })
+          }}
+        >
+          <Field type="string" name="a1" />
+          <Field type="string" name="a2" />
+        </SchemaForm>
+      </div>
+    )
+  }
+  const { queryAllByTestId } = render(<Component />)
+
+  await sleep(33)
+
+  expect(queryAllByTestId('test-input')[0].value).toEqual('')
+})


### PR DESCRIPTION
Fix #213 

过滤第一次onFieldChange的最佳方案可以参考测试用例，对pristine做过滤