### PR TITLE
fix(@uform/validator): Fix validate threshold check

### DIFF
--- a/packages/react/src/__tests__/validate.spec.js
+++ b/packages/react/src/__tests__/validate.spec.js
@@ -293,15 +293,16 @@ test('test idcard rules', async () => {
   const value5 = '12345678912345678X'
   // 18位数字
   const value6 = '123456789123456789'
+
   const element = await waitForElement(() => queryByTestId('test-input'))
   waitForDomChange({ container: element }).then(mutationsList => {
     const mutation = mutationsList[0]
     const { value } = mutation.target
     const errorTipsElement = queryByText('idCard is not an idcard format')
     if (value === value1 || value === value3) {
-      errorTipsElement.toBeVisible()
+      expect(errorTipsElement).toBeVisible()
     } else {
-      errorTipsElement.toBeNull()
+      expect(errorTipsElement).toBeNull()
     }
   })
   fireEvent.change(element, { target: { value: value1 } })
@@ -310,4 +311,39 @@ test('test idcard rules', async () => {
   fireEvent.change(element, { target: { value: value4 } })
   fireEvent.change(element, { target: { value: value5 } })
   fireEvent.change(element, { target: { value: value6 } })
+})
+
+test('dynamic switch visible', async () => {
+  const TestComponent = () => {
+    return (
+      <SchemaForm
+        initialValues={{ aa: '', bb: '' }}
+        effects={($, { setFieldState }) => {
+          $('onFieldChange', 'aa').subscribe(({ value }) => {
+            setFieldState('bb', state => {
+              state.visible = value == 'aa'
+            })
+          })
+        }}
+      >
+        <Field name="aa" type="string" />
+        <Field name="bb" type="string" required />
+      </SchemaForm>
+    )
+  }
+  const { queryAllByTestId, queryByText } = render(<TestComponent />)
+  await sleep(33)
+  fireEvent.change(queryAllByTestId('test-input')[0], {
+    target: { value: 'aa' }
+  })
+  await sleep(33)
+  fireEvent.change(queryAllByTestId('test-input')[0], {
+    target: { value: 'bb' }
+  })
+  await sleep(33)
+  fireEvent.change(queryAllByTestId('test-input')[0], {
+    target: { value: 'aa' }
+  })
+  await sleep(33)
+  expect(queryByText('bb is required')).toBeNull()
 })

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -7,7 +7,8 @@ import {
   isArr,
   isEqual,
   clone,
-  format
+  format,
+  isEmpty
 } from './utils'
 import { validate } from './validators'
 import { ValidateHandler, IValidateResponse, IFieldMap } from '@uform/types'
@@ -49,9 +50,13 @@ export const runValidation = async (
     ) {
       return
     }
-    if (isEqual(field.lastValidateValue, value) && !forceUpdate) {
-      return
+    if (!forceUpdate) {
+      if (isEmpty(field.lastValidateValue) && isEmpty(value)) return
+      if (isEqual(field.lastValidateValue, value)) {
+        return
+      }
     }
+
     const title = field.props && field.props.title
     const rafId = setTimeout(() => {
       field.loading = true


### PR DESCRIPTION
Fix #230 

问题原因：field.lastValidateValue默认是undefiend，同时只有第一次校验完了之后才会被赋值，所以就存在undefiend和空字符串不一致导致进入校验流程，所以需要加一个空值检查，如果两个都是空值，就不用判断相等了