### PR TITLE
fix(@uform/core): add scheduler backward compat

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -13,8 +13,8 @@ export * from '@uform/utils'
 
 const self = globalThisPolyfill
 
-const compactScheduler = ([raf, caf, priority]) => {
-  return [callback => raf(priority, callback), caf]
+const compactScheduler = ([raf, caf, priority], fresh: boolean) => {
+  return [fresh ? callback => raf(priority, callback) : raf, caf]
 }
 
 const getScheduler = () => {
@@ -24,11 +24,14 @@ const getScheduler = () => {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const scheduler = require('scheduler')
-    return compactScheduler([
-      scheduler.scheduleCallback || scheduler.unstable_scheduleCallback,
-      scheduler.cancelCallback || scheduler.unstable_cancelCallback,
-      scheduler.NormalPriority || scheduler.unstable_NormalPriority
-    ])
+    return compactScheduler(
+      [
+        scheduler.scheduleCallback || scheduler.unstable_scheduleCallback,
+        scheduler.cancelCallback || scheduler.unstable_cancelCallback,
+        scheduler.NormalPriority || scheduler.unstable_NormalPriority
+      ],
+      !!scheduler.unstable_requestPaint
+    )
   } catch (err) {
     return [self.requestAnimationFrame, self.cancelAnimationFrame]
   }


### PR DESCRIPTION
增加向后兼容逻辑，很hack，0.13.x以下的版本是不存在unstable_requestPaint这个API的，所以用这个来检测