### PR TITLE
fix(@uform/antd): fix antd upload types

### DIFF
--- a/packages/antd/src/fields/upload.tsx
+++ b/packages/antd/src/fields/upload.tsx
@@ -259,12 +259,7 @@ registerFormField(
               onRemove={this.onRemoveHandler}
               // TODO image 类型是跟 picture 一样 ?
               listType={listType.indexOf('image') > -1 ? 'picture' : 'text'}
-            >
-              <p className={'ant-upload-drag-icon'}>
-                <Icon type={'inbox'} />
-              </p>
-              <p className={'ant-upload-text'}>拖拽上传</p>
-            </UploadDragger>
+            />
           )
         }
         return (


### PR DESCRIPTION
antd upload 升级之后Dragger组件不允许传children了，只能干掉children，否则文档构建会报错