### PR TITLE
fix(antd): improve week type moment parse regex

### DIFF
--- a/docs/Examples/antd/International.md
+++ b/docs/Examples/antd/International.md
@@ -61,7 +61,7 @@ ReactDOM.render(
           type="week"
           title="周(自定义显示格式)"
           name="week1"
-          style={{ format: "gggg年 第w周" }}
+          style={{ format: 'gggg年 第w周' }}
         />
         <Field type="time" title="时间" name="time" />
         <Field

--- a/docs/Examples/antd/Sample.md
+++ b/docs/Examples/antd/Sample.md
@@ -94,7 +94,7 @@ ReactDOM.render(
         type="week"
         title="周(自定义显示格式)"
         name="week1"
-        style={{ format: "gggg年 第w周" }}
+        style={{ format: 'gggg年 第w周' }}
       />
       <Field type="time" title="时间" name="time" />
       <Field

--- a/packages/antd/src/fields/date.tsx
+++ b/packages/antd/src/fields/date.tsx
@@ -118,7 +118,7 @@ registerFormField(
       mapStyledProps,
       props => {
         if (isStr(props.value) && props.value) {
-          const parsed = props.value.match(/(\d+)\s*-\s*(\d+)/) || ['', '', '']
+          const parsed = props.value.match(/\D*(\d+)\D*(\d+)\D*/) || ['', '', ''];
           props.value = moment(parsed[1], 'YYYY').add(parsed[2], 'weeks')
         }
         return props

--- a/packages/antd/src/fields/date.tsx
+++ b/packages/antd/src/fields/date.tsx
@@ -118,8 +118,12 @@ registerFormField(
       mapStyledProps,
       props => {
         if (isStr(props.value) && props.value) {
-          const parsed = props.value.match(/\D*(\d+)\D*(\d+)\D*/) || ['', '', ''];
-          props.value = moment(parsed[1], 'YYYY').add(parsed[2], 'weeks')
+          const parsed = props.value.match(/\D*(\d+)\D*(\d+)\D*/) || [
+            '',
+            '',
+            ''
+          ]
+          props.value = moment(parsed[1], 'YYYY').add(parsed[2] - 1, 'weeks')
         }
         return props
       }

--- a/packages/antd/src/fields/date.tsx
+++ b/packages/antd/src/fields/date.tsx
@@ -118,11 +118,7 @@ registerFormField(
       mapStyledProps,
       props => {
         if (isStr(props.value) && props.value) {
-          const parsed = props.value.match(/\D*(\d+)\D*(\d+)\D*/) || [
-            '',
-            '',
-            ''
-          ]
+          const parsed = props.value.match(/\D*(\d+)\D*(\d+)\D*/) || ['', '', '']
           props.value = moment(parsed[1], 'YYYY').add(parsed[2] - 1, 'weeks')
         }
         return props


### PR DESCRIPTION
支持更多format属性的设定，比如 `format: 'gggg-w周'`、`format: 'gggg年 第w周 '`等