### PR TITLE
fix(core): Increase lastValidateValue value processing during initialization

### DIFF
--- a/packages/core/src/__test__/form.spec.js
+++ b/packages/core/src/__test__/form.spec.js
@@ -1,0 +1,46 @@
+import { createForm } from '../index'
+
+test('Increase lastValidateValue value processing during initialization', async () => {
+  const inpueFieldValidate = jest.fn()
+  const requriedFieldValidate = jest.fn()
+
+  const form = createForm({
+    initialValues: {
+      requriedField: 'defaultValue'
+    }
+  })
+
+  form.registerField('inpueField', {
+    props: {
+      requried: true,
+      'x-rules': () =>
+        new Promise(resolve => {
+          inpueFieldValidate()
+
+          resolve()
+        })
+    }
+  })
+
+  form.registerField('requriedField', {
+    props: {
+      requried: true,
+      'x-rules': () =>
+        new Promise(resolve => {
+          requriedFieldValidate()
+
+          resolve()
+        })
+    }
+  })
+
+  form.setValue('inpueField', 1111)
+  await sleep(1000)
+  expect(inpueFieldValidate).toHaveBeenCalledTimes(1)
+  expect(requriedFieldValidate).toHaveBeenCalledTimes(0)
+
+  form.setValue('requriedField', 2222)
+  await sleep(1000)
+  expect(inpueFieldValidate).toHaveBeenCalledTimes(1)
+  expect(requriedFieldValidate).toHaveBeenCalledTimes(1)
+})

--- a/packages/core/src/field.ts
+++ b/packages/core/src/field.ts
@@ -131,6 +131,10 @@ export class Field implements IField {
       this.editable = !isEmpty(editable) ? editable : this.getContextEditable()
     }
 
+    if (options.initialValue) {
+      this.lastValidateValue = options.initialValue
+    }
+
     if (
       this.pristine &&
       !isEmpty(this.initialValue) &&

--- a/packages/react/src/__tests__/schema_form.spec.js
+++ b/packages/react/src/__tests__/schema_form.spec.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import SchemaForm, { Field, registerFormField, connect } from '../index'
+
+registerFormField(
+  'string',
+  connect()(props => (
+    <input {...props} data-testid={props.testid} value={props.value || ''} />
+  ))
+)
+
+test('Increase lastValidateValue value processing during initialization', async () => {
+  const inpueFieldValidate = jest.fn()
+  const requriedFieldValidate = jest.fn()
+
+  const TestComponent = () => (
+    <SchemaForm initialValues={{ requriedField: 'defaultValue' }}>
+      <Field
+        requried
+        type="string"
+        title="inpueField"
+        name="inpueField"
+        x-props={{ testid: 'inpueField' }}
+        x-rules={() =>
+          new Promise(resolve => {
+            inpueFieldValidate()
+
+            resolve()
+          })
+        }
+      />
+      <Field
+        requried
+        type="string"
+        title="requriedField"
+        name="requriedField"
+        x-props={{ testid: 'requriedField' }}
+        x-rules={() =>
+          new Promise(resolve => {
+            requriedFieldValidate()
+
+            resolve()
+          })
+        }
+      />
+    </SchemaForm>
+  )
+
+  const { getByTestId } = render(<TestComponent />)
+  fireEvent.change(getByTestId('inpueField'), { target: { value: 1111 } })
+  await sleep(1000)
+  expect(inpueFieldValidate).toHaveBeenCalledTimes(1)
+  expect(requriedFieldValidate).toHaveBeenCalledTimes(0)
+
+  fireEvent.change(getByTestId('requriedField'), { target: { value: 2222 } })
+  await sleep(1000)
+  expect(inpueFieldValidate).toHaveBeenCalledTimes(1)
+  expect(requriedFieldValidate).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
close #263 

增加对 field 的 lastValidateValue 属性在有 initialValue 值的时候，进行对应赋值，避免在初次键入时，执行的 runValidation 中，values 的值是有该 field 的 initialValue 值，而 lastValidateValue 则为 undefined，从而导致了不必要的校验
