### PR TITLE
refactor: add a submitStart status to the Submit Component

### DIFF
--- a/packages/antd/src/__tests__/button.spec.js
+++ b/packages/antd/src/__tests__/button.spec.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { SchemaForm, Field, Submit } from '../index'
+
+test('fix repeat request', async () => {
+  const handleSubmit = jest.fn()
+
+  const TestComponent = () => (
+    <SchemaForm
+      labelCol={6}
+      wrapperCol={6}
+      onSubmit={handleSubmit}
+      defaultValue={{ custom: 'abc' }}
+    >
+      <Field
+        type="string"
+        name="custom"
+        required
+        x-rules={() =>
+          new Promise(resolve => {
+            setTimeout(() => {
+              // 延迟 1000ms 的异步校验
+              resolve()
+            }, 1000)
+          })
+        }
+        title="test: 不会因为存在异步校验而导致可重复点击提交"
+      />
+      <Submit data-testid="submit" showLoading />
+    </SchemaForm>
+  )
+
+  const { getByTestId } = render(<TestComponent />)
+
+  fireEvent.click(getByTestId('submit'))
+
+  await sleep(100)
+  fireEvent.click(getByTestId('submit'))
+  fireEvent.click(getByTestId('submit'))
+  fireEvent.click(getByTestId('submit'))
+
+  await sleep(1000)
+  expect(handleSubmit).toHaveBeenCalledTimes(1)
+})

--- a/packages/antd/src/components/button.tsx
+++ b/packages/antd/src/components/button.tsx
@@ -1,27 +1,66 @@
-import React from 'react'
-import { FormConsumer } from '@uform/react'
+import React, { useState, useEffect } from 'react'
+import { FormConsumer, IUseFormState } from '@uform/react'
+import { isFn } from '@uform/utils'
 import { Button } from 'antd'
 import { ISubmitProps } from '../type'
 
-export const Submit = ({ showLoading, ...props }: ISubmitProps) => {
+interface ISubmitComponentProps extends ISubmitProps {
+  useFormState: IUseFormState
+}
+
+const SUBMIT_START = 'submitStart'
+
+const SubmitComponent = ({
+  showLoading,
+  useFormState: { submit, status },
+  ...props
+}: ISubmitComponentProps) => {
+  /**
+   * @see https://github.com/alibaba/uform/blob/4009d7834e883bf2d7cb5aef2c4bcc7981924f6a/packages/core/src/form.ts#L543
+   *
+   * 因为 submitting 的状态是在校验完成之后才生成的
+   * 而如果校验耗时较长就会导致 submitting 的生成延迟
+   * 而在这之前，Submit 组件就一直处于可以点击的状态，容易造成重复提交
+   */
+  const [submitStatus, setSubmitStatus] = useState('')
+
+  useEffect(() => {
+    setSubmitStatus(status)
+  }, [status])
+
+  const handleSubmit = () => {
+    // 新增 submitStart 状态用于标识 Submit 被初始点击
+    setSubmitStatus(SUBMIT_START)
+
+    if (isFn(submit)) {
+      submit()
+    }
+  }
+
+  const disabledState = showLoading
+    ? [SUBMIT_START, 'submitting'].includes(submitStatus)
+    : undefined
+
   return (
-    <FormConsumer selector={['submitting', 'submitted']}>
-      {({ status }) => {
-        return (
-          <Button
-            type={'primary'}
-            htmlType={'submit'}
-            disabled={showLoading ? status === 'submitting' : undefined}
-            {...props}
-            loading={showLoading ? status === 'submitting' : undefined}
-          >
-            {props.children || '提交'}
-          </Button>
-        )
-      }}
-    </FormConsumer>
+    <Button
+      type="primary"
+      disabled={disabledState}
+      {...props}
+      loading={showLoading ? submitStatus === 'submitting' : undefined}
+      onClick={handleSubmit}
+    >
+      {props.children || '提交'}
+    </Button>
   )
 }
+
+export const Submit = (props: ISubmitProps) => (
+  <FormConsumer selector={['submitting', 'submitted']}>
+    {(useFormState: IUseFormState) => (
+      <SubmitComponent {...{ useFormState, ...props }} />
+    )}
+  </FormConsumer>
+)
 
 export const Reset = props => {
   return (

--- a/packages/antd/src/components/button.tsx
+++ b/packages/antd/src/components/button.tsx
@@ -4,16 +4,12 @@ import { Button } from 'antd'
 import { ISubmitProps } from '../type'
 
 export const Submit = ({ showLoading, ...props }: ISubmitProps) => (
-  <FormConsumer selector={['submitStarted', 'submitting', 'submitted']}>
+  <FormConsumer selector={['submitting', 'submitted']}>
     {({ status }: IUseFormState) => (
       <Button
         type="primary"
         htmlType="submit"
-        disabled={
-          showLoading
-            ? ['submitStarted', 'submitting'].includes(status)
-            : undefined
-        }
+        disabled={showLoading ? status === 'submitting' : undefined}
         {...props}
         loading={showLoading ? status === 'submitting' : undefined}
       >

--- a/packages/antd/src/components/button.tsx
+++ b/packages/antd/src/components/button.tsx
@@ -1,63 +1,24 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { FormConsumer, IUseFormState } from '@uform/react'
-import { isFn } from '@uform/utils'
 import { Button } from 'antd'
 import { ISubmitProps } from '../type'
 
-interface ISubmitComponentProps extends ISubmitProps {
-  useFormState: IUseFormState
-}
-
-const SUBMIT_START = 'submitStart'
-
-const SubmitComponent = ({
-  showLoading,
-  useFormState: { submit, status },
-  ...props
-}: ISubmitComponentProps) => {
-  /**
-   * @see https://github.com/alibaba/uform/blob/4009d7834e883bf2d7cb5aef2c4bcc7981924f6a/packages/core/src/form.ts#L543
-   *
-   * 因为 submitting 的状态是在校验完成之后才生成的
-   * 而如果校验耗时较长就会导致 submitting 的生成延迟
-   * 而在这之前，Submit 组件就一直处于可以点击的状态，容易造成重复提交
-   */
-  const [submitStatus, setSubmitStatus] = useState('')
-
-  useEffect(() => {
-    setSubmitStatus(status)
-  }, [status])
-
-  const handleSubmit = () => {
-    // 新增 submitStart 状态用于标识 Submit 被初始点击
-    setSubmitStatus(SUBMIT_START)
-
-    if (isFn(submit)) {
-      submit()
-    }
-  }
-
-  const disabledState = showLoading
-    ? [SUBMIT_START, 'submitting'].includes(submitStatus)
-    : undefined
-
-  return (
-    <Button
-      type="primary"
-      disabled={disabledState}
-      {...props}
-      loading={showLoading ? submitStatus === 'submitting' : undefined}
-      onClick={handleSubmit}
-    >
-      {props.children || '提交'}
-    </Button>
-  )
-}
-
-export const Submit = (props: ISubmitProps) => (
-  <FormConsumer selector={['submitting', 'submitted']}>
-    {(useFormState: IUseFormState) => (
-      <SubmitComponent {...{ useFormState, ...props }} />
+export const Submit = ({ showLoading, ...props }: ISubmitProps) => (
+  <FormConsumer selector={['submitStarted', 'submitting', 'submitted']}>
+    {({ status }: IUseFormState) => (
+      <Button
+        type="primary"
+        htmlType="submit"
+        disabled={
+          showLoading
+            ? ['submitStarted', 'submitting'].includes(status)
+            : undefined
+        }
+        {...props}
+        loading={showLoading ? status === 'submitting' : undefined}
+      >
+        {props.children || '提交'}
+      </Button>
     )}
   </FormConsumer>
 )

--- a/packages/core/src/form.ts
+++ b/packages/core/src/form.ts
@@ -569,13 +569,21 @@ export class Form {
     // 标记正在处理 submit 处理流程
     this.setSubmitting(true)
 
-    return this.validate().then((formState: IFormState) => {
-      this.dispatchEffect('onFormSubmit', formState)
-      if (isFn(this.options.onSubmit)) {
-        this.options.onSubmit({ formState })
-      }
-      return formState
-    })
+    return this.validate()
+      .then((formState: IFormState) => {
+        this.dispatchEffect('onFormSubmit', formState)
+
+        if (isFn(this.options.onSubmit)) {
+          this.options.onSubmit({ formState })
+        }
+
+        return formState
+      })
+      .catch(e => {
+        this.setSubmitting(false)
+
+        throw e
+      })
   }
 
   public subscribe(callback: (payload: any) => void) {

--- a/packages/core/src/form.ts
+++ b/packages/core/src/form.ts
@@ -82,6 +82,9 @@ export class Form {
 
   private batchUpdateField: boolean
 
+  // submit 提交中的状态
+  private submitting: boolean = false
+
   private traverse: (schema: ISchema) => ISchema
 
   constructor(opts: IFormOptions) {
@@ -104,6 +107,14 @@ export class Form {
     this.initialized = true
     this.destructed = false
     this.fieldSize = 0
+  }
+
+  public getSubmitting() {
+    return this.submitting
+  }
+
+  public setSubmitting(type: boolean) {
+    this.submitting = type
   }
 
   public changeValues(values: any) {
@@ -541,6 +552,13 @@ export class Form {
   }
 
   public submit() {
+    if (this.getSubmitting()) {
+      return Promise.resolve(this.publishState())
+    }
+
+    // 标记正在处理 submit 处理流程
+    this.setSubmitting(true)
+
     return this.validate().then((formState: IFormState) => {
       this.dispatchEffect('onFormSubmit', formState)
       if (isFn(this.options.onSubmit)) {

--- a/packages/next/src/__tests__/button.spec.js
+++ b/packages/next/src/__tests__/button.spec.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { SchemaForm, Field, Submit } from '../index'
+
+test('fix repeat request', async () => {
+  const handleSubmit = jest.fn()
+
+  const TestComponent = () => (
+    <SchemaForm
+      labelCol={6}
+      wrapperCol={6}
+      onSubmit={handleSubmit}
+      defaultValue={{ custom: 'abc' }}
+    >
+      <Field
+        type="string"
+        name="custom"
+        required
+        x-rules={() =>
+          new Promise(resolve => {
+            setTimeout(() => {
+              // 延迟 1000ms 的异步校验
+              resolve()
+            }, 1000)
+          })
+        }
+        title="test: 不会因为存在异步校验而导致可重复点击提交"
+      />
+      <Submit data-testid="submit" showLoading />
+    </SchemaForm>
+  )
+
+  const { getByTestId } = render(<TestComponent />)
+
+  fireEvent.click(getByTestId('submit'))
+
+  await sleep(100)
+  fireEvent.click(getByTestId('submit'))
+  fireEvent.click(getByTestId('submit'))
+  fireEvent.click(getByTestId('submit'))
+
+  await sleep(1000)
+  expect(handleSubmit).toHaveBeenCalledTimes(1)
+})

--- a/packages/next/src/components/button.tsx
+++ b/packages/next/src/components/button.tsx
@@ -1,37 +1,72 @@
-import React from 'react'
-import { FormConsumer } from '@uform/react'
+import React, { useState, useEffect } from 'react'
+import { FormConsumer, IUseFormState } from '@uform/react'
+import { isFn } from '@uform/utils'
 import { Button } from '@alifd/next'
-import { ButtonProps } from '@alifd/next/types/button'
+import { ISubmitProps } from '../type'
 
-export interface ISubmitProps extends Omit<ButtonProps, 'loading'> {
-  showLoading?: boolean
+interface ISubmitComponentProps extends ISubmitProps {
+  useFormState: IUseFormState
 }
 
-export const Submit = ({ showLoading, ...props }: ISubmitProps) => {
+const SUBMIT_START = 'submitStart'
+
+const SubmitComponent = ({
+  showLoading,
+  useFormState: { submit, status },
+  ...props
+}: ISubmitComponentProps) => {
+  /**
+   * @see https://github.com/alibaba/uform/blob/4009d7834e883bf2d7cb5aef2c4bcc7981924f6a/packages/core/src/form.ts#L543
+   *
+   * 因为 submitting 的状态是在校验完成之后才生成的
+   * 而如果校验耗时较长就会导致 submitting 的生成延迟
+   * 而在这之前，Submit 组件就一直处于可以点击的状态，容易造成重复提交
+   */
+  const [submitStatus, setSubmitStatus] = useState('')
+
+  useEffect(() => {
+    setSubmitStatus(status)
+  }, [status])
+
+  const handleSubmit = () => {
+    // 新增 submitStart 状态用于标识 Submit 被初始点击
+    setSubmitStatus(SUBMIT_START)
+
+    if (isFn(submit)) {
+      submit()
+    }
+  }
+
+  const disabledState = showLoading
+    ? [SUBMIT_START, 'submitting'].includes(submitStatus)
+    : undefined
+
   return (
-    <FormConsumer selector={['submitting', 'submitted']}>
-      {({ status }) => {
-        return (
-          <Button
-            type="primary"
-            htmlType="submit"
-            disabled={showLoading ? status === 'submitting' : undefined}
-            {...props}
-            loading={showLoading ? status === 'submitting' : undefined}
-          >
-            {props.children || '提交'}
-          </Button>
-        )
-      }}
-    </FormConsumer>
+    <Button
+      type="primary"
+      disabled={disabledState}
+      {...props}
+      loading={showLoading ? submitStatus === 'submitting' : undefined}
+      onClick={handleSubmit}
+    >
+      {props.children || '提交'}
+    </Button>
   )
 }
+
+export const Submit = (props: ISubmitProps) => (
+  <FormConsumer selector={['submitting', 'submitted']}>
+    {(useFormState: IUseFormState) => (
+      <SubmitComponent {...{ useFormState, ...props }} />
+    )}
+  </FormConsumer>
+)
 
 Submit.defaultProps = {
   showLoading: true
 }
 
-export const Reset = (props: ButtonProps) => {
+export const Reset: React.FC<Omit<ISubmitProps, 'showLoading'>> = props => {
   return (
     <FormConsumer>
       {({ reset }) => {

--- a/packages/next/src/components/button.tsx
+++ b/packages/next/src/components/button.tsx
@@ -4,16 +4,12 @@ import { Button } from '@alifd/next'
 import { ISubmitProps } from '../type'
 
 export const Submit = ({ showLoading, ...props }: ISubmitProps) => (
-  <FormConsumer selector={['submitStarted', 'submitting', 'submitted']}>
+  <FormConsumer selector={['submitting', 'submitted']}>
     {({ status }: IUseFormState) => (
       <Button
         type="primary"
         htmlType="submit"
-        disabled={
-          showLoading
-            ? ['submitStarted', 'submitting'].includes(status)
-            : undefined
-        }
+        disabled={showLoading ? status === 'submitting' : undefined}
         {...props}
         loading={showLoading ? status === 'submitting' : undefined}
       >

--- a/packages/next/src/components/button.tsx
+++ b/packages/next/src/components/button.tsx
@@ -1,70 +1,27 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { FormConsumer, IUseFormState } from '@uform/react'
-import { isFn } from '@uform/utils'
 import { Button } from '@alifd/next'
 import { ISubmitProps } from '../type'
 
-interface ISubmitComponentProps extends ISubmitProps {
-  useFormState: IUseFormState
-}
-
-const SUBMIT_START = 'submitStart'
-
-const SubmitComponent = ({
-  showLoading,
-  useFormState: { submit, status },
-  ...props
-}: ISubmitComponentProps) => {
-  /**
-   * @see https://github.com/alibaba/uform/blob/4009d7834e883bf2d7cb5aef2c4bcc7981924f6a/packages/core/src/form.ts#L543
-   *
-   * 因为 submitting 的状态是在校验完成之后才生成的
-   * 而如果校验耗时较长就会导致 submitting 的生成延迟
-   * 而在这之前，Submit 组件就一直处于可以点击的状态，容易造成重复提交
-   */
-  const [submitStatus, setSubmitStatus] = useState('')
-
-  useEffect(() => {
-    setSubmitStatus(status)
-  }, [status])
-
-  const handleSubmit = () => {
-    // 新增 submitStart 状态用于标识 Submit 被初始点击
-    setSubmitStatus(SUBMIT_START)
-
-    if (isFn(submit)) {
-      submit()
-    }
-  }
-
-  const disabledState = showLoading
-    ? [SUBMIT_START, 'submitting'].includes(submitStatus)
-    : undefined
-
-  return (
-    <Button
-      type="primary"
-      disabled={disabledState}
-      {...props}
-      loading={showLoading ? submitStatus === 'submitting' : undefined}
-      onClick={handleSubmit}
-    >
-      {props.children || '提交'}
-    </Button>
-  )
-}
-
-export const Submit = (props: ISubmitProps) => (
-  <FormConsumer selector={['submitting', 'submitted']}>
-    {(useFormState: IUseFormState) => (
-      <SubmitComponent {...{ useFormState, ...props }} />
+export const Submit = ({ showLoading, ...props }: ISubmitProps) => (
+  <FormConsumer selector={['submitStarted', 'submitting', 'submitted']}>
+    {({ status }: IUseFormState) => (
+      <Button
+        type="primary"
+        htmlType="submit"
+        disabled={
+          showLoading
+            ? ['submitStarted', 'submitting'].includes(status)
+            : undefined
+        }
+        {...props}
+        loading={showLoading ? status === 'submitting' : undefined}
+      >
+        {props.children || '提交'}
+      </Button>
     )}
   </FormConsumer>
 )
-
-Submit.defaultProps = {
-  showLoading: true
-}
 
 export const Reset: React.FC<Omit<ISubmitProps, 'showLoading'>> = props => (
   <FormConsumer>

--- a/packages/react/src/__tests__/schema_form.spec.js
+++ b/packages/react/src/__tests__/schema_form.spec.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 
-import SchemaForm, { Field, registerFormField, connect } from '../index'
+import SchemaForm, {
+  Field,
+  registerFormField,
+  connect,
+  createFormActions
+} from '../index'
 
 registerFormField(
   'string',
@@ -57,4 +62,127 @@ test('Increase lastValidateValue value processing during initialization', async 
   await sleep(1000)
   expect(inpueFieldValidate).toHaveBeenCalledTimes(1)
   expect(requriedFieldValidate).toHaveBeenCalledTimes(1)
+})
+
+const TestSubmitComponent = ({ children, ...props }) => (
+  <SchemaForm {...props}>
+    <Field
+      type="string"
+      x-rules={() =>
+        new Promise(resolve => {
+          // 延迟 1000ms 的异步校验
+          setTimeout(() => {
+            resolve()
+          }, 1000)
+        })
+      }
+    />
+    {children}
+  </SchemaForm>
+)
+
+test('test button submit type trigger onSubmit', async () => {
+  const handleSubmit = jest.fn()
+
+  const TestComponent = () => (
+    <TestSubmitComponent onSubmit={handleSubmit}>
+      <button type="submit" data-testid="submit">
+        submit
+      </button>
+    </TestSubmitComponent>
+  )
+
+  const { getByTestId } = render(<TestComponent />)
+
+  fireEvent.click(getByTestId('submit'))
+
+  await sleep(100)
+  fireEvent.click(getByTestId('submit'))
+  fireEvent.click(getByTestId('submit'))
+  fireEvent.click(getByTestId('submit'))
+
+  await sleep(1000)
+  expect(handleSubmit).toHaveBeenCalledTimes(1)
+})
+
+test('test actions.submit trigger onSubmit', async () => {
+  const handleSubmit = jest.fn()
+
+  const actions = createFormActions()
+
+  const TestComponent = () => (
+    <TestSubmitComponent actions={actions} onSubmit={handleSubmit}>
+      <button
+        data-testid="submit"
+        onClick={() => {
+          actions.submit()
+        }}
+      >
+        submit
+      </button>
+    </TestSubmitComponent>
+  )
+
+  const { getByTestId } = render(<TestComponent />)
+
+  fireEvent.click(getByTestId('submit'))
+
+  await sleep(100)
+  fireEvent.click(getByTestId('submit'))
+  fireEvent.click(getByTestId('submit'))
+  fireEvent.click(getByTestId('submit'))
+
+  await sleep(1000)
+  expect(handleSubmit).toHaveBeenCalledTimes(1)
+})
+
+test('test actions.submit and button submit type trigger onSubmit', async () => {
+  const handleSubmit = jest.fn()
+
+  const actions = createFormActions()
+
+  const TestComponent = () => (
+    <TestSubmitComponent
+      actions={actions}
+      onSubmit={() =>
+        new Promise(resolve => {
+          handleSubmit()
+          resolve()
+        })
+      }
+    >
+      <button type="submit" data-testid="htmlSubmit">
+        htmlSubmit
+      </button>
+      <button
+        data-testid="actionSubmit"
+        onClick={() => {
+          actions.submit()
+        }}
+      >
+        actionSubmit
+      </button>
+    </TestSubmitComponent>
+  )
+
+  const { getByTestId } = render(<TestComponent />)
+
+  fireEvent.click(getByTestId('htmlSubmit'))
+  await sleep(100)
+  fireEvent.click(getByTestId('actionSubmit'))
+  fireEvent.click(getByTestId('actionSubmit'))
+  fireEvent.click(getByTestId('actionSubmit'))
+
+  await sleep(1000)
+  expect(handleSubmit).toHaveBeenCalledTimes(1)
+
+  // actions.submit
+  fireEvent.click(getByTestId('actionSubmit'))
+  await sleep(100)
+  fireEvent.click(getByTestId('htmlSubmit'))
+  fireEvent.click(getByTestId('htmlSubmit'))
+  fireEvent.click(getByTestId('htmlSubmit'))
+
+  await sleep(1000)
+  expect(handleSubmit).toHaveBeenCalledTimes(2)
 })

--- a/packages/react/src/shared/broadcast.tsx
+++ b/packages/react/src/shared/broadcast.tsx
@@ -1,6 +1,6 @@
 import React, { Component, useContext, useMemo, useState } from 'react'
 import { IBroadcast, isArr, isFn, isStr } from '@uform/utils'
-import { ISelector, IFormActions } from '@uform/types'
+import { ISelector, IFormActions, ISchema } from '@uform/types'
 import { useEva, createActions } from 'react-eva'
 import { Broadcast } from '../utils'
 import { BroadcastContext, StateContext } from './context'
@@ -56,6 +56,15 @@ export interface IFormState {
   status?: any
   state?: object
   schema?: object
+}
+
+export interface IUseFormState {
+  status: 'changed' | 'reseted' | 'initialize' | 'submitting' | 'submitted'
+  state: IFormState
+  schema: ISchema
+  submit: () => void
+  reset: () => void
+  dispatch: (name: string, payload: any) => void
 }
 
 export const useForm = (options: IOption = {}) => {

--- a/packages/react/src/state/form.tsx
+++ b/packages/react/src/state/form.tsx
@@ -246,11 +246,7 @@ export const StateForm = createHOC((options, Form) => {
         return
       }
 
-      this.submit().catch(e => {
-        if (console && console.error) {
-          console.error(e)
-        }
-      })
+      this.submit()
     }
 
     public getValues = () => {
@@ -264,7 +260,20 @@ export const StateForm = createHOC((options, Form) => {
         state: this.formState
       })
 
-      return this.form.submit()
+      return this.form.submit().catch(e => {
+        this.notify({
+          type: 'submitted',
+          state: this.formState
+        })
+
+        this.form.setSubmitting(false)
+
+        if (console && console.error) {
+          console.error(e)
+        }
+
+        return e
+      })
     }
 
     public reset = (

--- a/packages/react/src/state/form.tsx
+++ b/packages/react/src/state/form.tsx
@@ -158,12 +158,17 @@ export const StateForm = createHOC((options, Form) => {
                   type: 'submitted',
                   state: this.formState
                 })
+
+                this.form.setSubmitting(false)
               },
               error => {
                 this.notify({
                   type: 'submitted',
                   state: this.formState
                 })
+
+                this.form.setSubmitting(false)
+
                 throw error
               }
             )
@@ -236,7 +241,12 @@ export const StateForm = createHOC((options, Form) => {
         e.stopPropagation()
         e.preventDefault()
       }
-      this.form.submit().catch(e => {
+
+      if (this.form.getSubmitting()) {
+        return
+      }
+
+      this.submit().catch(e => {
         if (console && console.error) {
           console.error(e)
         }
@@ -248,6 +258,12 @@ export const StateForm = createHOC((options, Form) => {
     }
 
     public submit = () => {
+      // 生成 submitStart 状态，用于 Submit 组件呈现正确的 UI 反馈
+      this.notify({
+        type: 'submitStart',
+        state: this.formState
+      })
+
       return this.form.submit()
     }
 

--- a/packages/react/src/state/form.tsx
+++ b/packages/react/src/state/form.tsx
@@ -145,6 +145,9 @@ export const StateForm = createHOC((options, Form) => {
     public onSubmitHandler = $props => {
       return ({ formState }) => {
         const props = this.props || $props
+
+        const closeSubmitting = () => this.form.setSubmitting(false)
+
         if (props.onSubmit) {
           const promise = props.onSubmit(clone(formState.values))
           if (promise && promise.then) {
@@ -159,7 +162,7 @@ export const StateForm = createHOC((options, Form) => {
                   state: this.formState
                 })
 
-                this.form.setSubmitting(false)
+                closeSubmitting()
               },
               error => {
                 this.notify({
@@ -167,13 +170,17 @@ export const StateForm = createHOC((options, Form) => {
                   state: this.formState
                 })
 
-                this.form.setSubmitting(false)
+                closeSubmitting()
 
                 throw error
               }
             )
+
+            return
           }
         }
+
+        closeSubmitting()
       }
     }
 
@@ -246,7 +253,11 @@ export const StateForm = createHOC((options, Form) => {
         return
       }
 
-      this.submit()
+      this.submit().catch(e => {
+        if (console && console.error) {
+          console.error(e)
+        }
+      })
     }
 
     public getValues = () => {
@@ -254,26 +265,7 @@ export const StateForm = createHOC((options, Form) => {
     }
 
     public submit = () => {
-      // 生成 submitStart 状态，用于 Submit 组件呈现正确的 UI 反馈
-      this.notify({
-        type: 'submitStart',
-        state: this.formState
-      })
-
-      return this.form.submit().catch(e => {
-        this.notify({
-          type: 'submitted',
-          state: this.formState
-        })
-
-        this.form.setSubmitting(false)
-
-        if (console && console.error) {
-          console.error(e)
-        }
-
-        return e
-      })
+      return this.form.submit()
     }
 
     public reset = (


### PR DESCRIPTION
close #265 

## 问题描述
因为 submitting 的状态是在校验完成之后才生成的，而如果校验耗时较长就会导致 submitting 的生成延迟，而在这之前，Submit 组件就一直处于可以点击的状态，容易造成重复提交

[问题源头的代码](https://github.com/alibaba/uform/blob/4009d7834e883bf2d7cb5aef2c4bcc7981924f6a/packages/core/src/form.ts#L543)