### PR TITLE
fix: when remove a column, you need to delete the corresponding form.field

### DIFF
--- a/packages/core/src/form.ts
+++ b/packages/core/src/form.ts
@@ -554,6 +554,12 @@ export class Form {
     return this.publisher.subscribe(callback)
   }
 
+  public unloadField(name: string) {
+    if (this.fields[name]) {
+      delete this.fields[name]
+    }
+  }
+
   public destructor() {
     if (this.destructed) {
       return

--- a/packages/react/src/__tests__/array.spec.js
+++ b/packages/react/src/__tests__/array.spec.js
@@ -1,0 +1,145 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import SchemaForm, {
+  Field,
+  registerFormField,
+  connect,
+  createArrayField
+} from '../index'
+
+registerFormField(
+  'string',
+  connect({
+    getProps: (props, { errors, name }) => {
+      props.idx = name
+      props.errors = errors
+    }
+  })(props => (
+    <div>
+      <input {...props} data-testid={props.idx} value={props.value || ''} />
+      {!!props.errors.length && (
+        <span data-testid={`${props.idx}_error`}>{props.errors[0]}</span>
+      )}
+    </div>
+  ))
+)
+
+const ArrayField = createArrayField()
+
+registerFormField(
+  'table',
+  class extends ArrayField {
+    render() {
+      const { value, schema, renderField } = this.props
+
+      const Column = ({ item, index }) => (
+        <div>
+          {Object.keys(schema.items.properties).map(key => (
+            <div key={key}>
+              {renderField([index, key])}
+
+              <div>
+                {this.renderRemove(index, item)}
+                {this.renderMoveDown(index, item)}
+                {this.renderMoveUp(index)}
+                {this.renderExtraOperations(index)}
+              </div>
+            </div>
+          ))}
+        </div>
+      )
+
+      return (
+        <div>
+          <div>
+            {value.map((item, index) => (
+              <Column key={index} {...{ item, index }} />
+            ))}
+          </div>
+
+          {this.renderAddition()}
+        </div>
+      )
+    }
+  }
+)
+
+test('make sure deleted column data is removed from Form fieldssetFieldState will trigger validate', async () => {
+  const TestComponent = () => {
+    return (
+      <SchemaForm>
+        <Field
+          name="array"
+          type="array"
+          x-component="table"
+          x-props={{
+            renderAddition: ({ add }) => {
+              return (
+                <a
+                  data-testid="add"
+                  onClick={e => {
+                    e.preventDefault()
+                    add(e)
+                  }}
+                >
+                  add config
+                </a>
+              )
+            },
+            renderRemove: ({ index, remove }) => {
+              return (
+                <a
+                  data-testid={`delete_${index}`}
+                  onClick={e => {
+                    e.preventDefault()
+                    remove(e, index)
+                  }}
+                >
+                  delete
+                </a>
+              )
+            },
+            renderMoveDown: () => <span />,
+            renderMoveUp: () => <span />,
+            operationsWidth: 50
+          }}
+        >
+          <Field type="object">
+            <Field
+              data-testid="test-input"
+              name="test-input"
+              type="string"
+              required
+            />
+          </Field>
+        </Field>
+      </SchemaForm>
+    )
+  }
+
+  const { getByTestId, queryByText } = render(<TestComponent />)
+
+  fireEvent.click(getByTestId('add'))
+  await sleep(33)
+  fireEvent.click(getByTestId('add'))
+
+  fireEvent.change(getByTestId('array.1.test-input'), {
+    target: { value: 'aa' }
+  })
+  await sleep(33)
+  fireEvent.change(getByTestId('array.1.test-input'), {
+    target: { value: '' }
+  })
+
+  await sleep(33)
+  expect(queryByText('array.1.test-input is required')).toBeVisible()
+
+  await sleep(33)
+  fireEvent.click(getByTestId('delete_1'))
+
+  await sleep(33)
+  fireEvent.click(getByTestId('add'))
+
+  await sleep(33)
+  expect(queryByText('array.1.test-input is required')).toBeNull()
+})

--- a/packages/react/src/shared/array.tsx
+++ b/packages/react/src/shared/array.tsx
@@ -238,13 +238,17 @@ export const createArrayField = (
 
     // TODO e 类型
     public onRemoveHandler(index: number): (e: any) => void {
-      const { value, mutators, schema, locale } = this.props
+      const { value, mutators, schema, locale, schemaPath, form } = this.props
       const { minItems } = schema
       return e => {
         e.stopPropagation()
         if (minItems >= 0 && value.length - 1 < minItems) {
           mutators.errors(locale.array_invalid_minItems, minItems)
         } else {
+          Object.keys(schema.items.properties).forEach(k => {
+            form.unloadField([...schemaPath, index, k].join('.'))
+          })
+
           mutators.remove(index)
         }
       }


### PR DESCRIPTION
close #267 

----
### 原因
array 组件在执行 remove 的时候，没有正确删除对应的 form.field

ps: 感觉可以保留这个处理，算是一个优化性能的点？减少创建 field 的开销，不过需要在 remove 后，再 add 时候，正确重置对应的 form.field 😬