### PR TITLE
fix: ButtonGroup missing the definition of align prop

### DIFF
--- a/packages/antd/src/type.tsx
+++ b/packages/antd/src/type.tsx
@@ -120,11 +120,11 @@ export interface IFormButtonGroupProps {
   style?: React.CSSProperties
   itemStyle?: React.CSSProperties
   className?: string
-
+  align?: 'left' | 'right' | 'start' | 'end' | 'top' | 'bottom' | 'center'
   triggerDistance?: number
   zIndex?: number
-  span?: number
-  offset?: number
+  span?: ColSpanType
+  offset?: ColSpanType
 }
 
 export interface ISubmitProps extends Omit<BaseButtonProps, 'loading'> {

--- a/packages/next/src/type.tsx
+++ b/packages/next/src/type.tsx
@@ -99,11 +99,11 @@ export interface IFormButtonGroupProps {
   style?: React.CSSProperties
   itemStyle?: React.CSSProperties
   className?: string
-
+  align?: 'left' | 'right' | 'start' | 'end' | 'top' | 'bottom' | 'center'
   triggerDistance?: number
   zIndex?: number
-  span?: number
-  offset?: number
+  span?: ColSpanType
+  offset?: ColSpanType
 }
 
 export interface SchemaFormProps<V = unknown> {


### PR DESCRIPTION
补全 IFormButtonGroupProps 缺失的 align 定义