### PR TITLE
Fix text equal

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@babel/runtime-corejs3": "^7.2.0",
     "@testing-library/react": "^8.0.0",
     "@types/node": "^12.6.8",
-    "@types/react": "^16.8.23",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
     "all-contributors-cli": "^6.1.2",

--- a/packages/antd/src/utils.tsx
+++ b/packages/antd/src/utils.tsx
@@ -44,8 +44,8 @@ const Text = styled(props => {
   if (props.dataSource && props.dataSource.length) {
     const find = props.dataSource.filter(({ value }) =>
       Array.isArray(props.value)
-        ? props.value.indexOf(value) > -1
-        : props.value === value
+        ? props.value.some(val => val == value)
+        : props.value == value
     )
     value = find.map(item => item.label).join(' , ')
   } else {

--- a/packages/next/src/utils.tsx
+++ b/packages/next/src/utils.tsx
@@ -12,8 +12,8 @@ const Text = styled(props => {
   if (props.dataSource && props.dataSource.length) {
     let find = props.dataSource.filter(({ value }) =>
       Array.isArray(props.value)
-        ? props.value.indexOf(value) > -1
-        : props.value === value
+        ? props.value.some(val => val == value)
+        : props.value == value
     )
     value = find.map(item => item.label).join(' , ')
   } else {


### PR DESCRIPTION
详情模式下的文本匹配之前采用的强等匹配，这个实在太严格了，对于后端接口来说，很难满足强等