### PR TITLE
fix(@uform/antd): Warning: Received `true` for a non-boolean attribute `inline`

### DIFF
--- a/packages/antd/src/compat/Form.tsx
+++ b/packages/antd/src/compat/Form.tsx
@@ -11,14 +11,15 @@ import {
 export const CompatAntdForm: React.FC<FormProps &
   IFormItemTopProps &
   PreviewTextConfigProps> = props => {
+  const { inline, ...rest } = props;
   return (
     <FormItemProvider {...props}>
       <PreviewText.ConfigProvider value={props}>
         <Form
-          {...props}
+          {...rest}
           labelCol={normalizeCol(props.labelCol)}
           wrapperCol={normalizeCol(props.wrapperCol)}
-          layout={props.inline ? 'inline' : props.layout}
+          layout={inline ? 'inline' : props.layout}
           form={undefined}
         />
       </PreviewText.ConfigProvider>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13229469/70535254-ade99700-1b97-11ea-876f-a981421ee1e3.png)
