### PR TITLE
fix(@uform/antd/next): onSubmit type merge error

### DIFF
--- a/packages/antd/src/types.ts
+++ b/packages/antd/src/types.ts
@@ -17,7 +17,9 @@ type ColSpanType = number | string
 export type IAntdSchemaFormProps = FormProps &
   IFormItemTopProps &
   PreviewTextConfigProps &
-  ISchemaFormProps
+  ISchemaFormProps | {
+    onSubmit?: ISchemaFormProps['onSubmit']
+  }
 
 export type IAntdSchemaFieldProps = IMarkupSchemaFieldProps
 

--- a/packages/antd/src/types.ts
+++ b/packages/antd/src/types.ts
@@ -14,12 +14,10 @@ import { StyledComponent } from 'styled-components'
 
 type ColSpanType = number | string
 
-export type IAntdSchemaFormProps = FormProps &
+export type IAntdSchemaFormProps = Omit<FormProps, 'onSubmit'> &
   IFormItemTopProps &
   PreviewTextConfigProps &
-  ISchemaFormProps | {
-    onSubmit?: ISchemaFormProps['onSubmit']
-  }
+  ISchemaFormProps
 
 export type IAntdSchemaFieldProps = IMarkupSchemaFieldProps
 

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -11,12 +11,10 @@ import { StyledComponent } from 'styled-components'
 
 type ColSpanType = number | string
 
-export type INextSchemaFormProps = FormProps &
+export type INextSchemaFormProps = Omit<FormProps, 'onSubmit'> &
   IFormItemTopProps &
   PreviewTextConfigProps &
-  ISchemaFormProps | {
-    onSubmit?: ISchemaFormProps['onSubmit']
-  }
+  ISchemaFormProps
 
 export type INextSchemaFieldProps = IMarkupSchemaFieldProps
 

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -14,7 +14,9 @@ type ColSpanType = number | string
 export type INextSchemaFormProps = FormProps &
   IFormItemTopProps &
   PreviewTextConfigProps &
-  ISchemaFormProps
+  ISchemaFormProps | {
+    onSubmit?: ISchemaFormProps['onSubmit']
+  }
 
 export type INextSchemaFieldProps = IMarkupSchemaFieldProps
 


### PR DESCRIPTION
由于使用联合类型 & 会导致同名成员变量也根据 & 叠加，因此针对onSubmit用omit来提取

```typescript
type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
```