### PR TITLE
fix: `false` should be a valid value in `PreviewText.Select` (fix #1296)

### DIFF
--- a/packages/antd/src/preview-text/index.tsx
+++ b/packages/antd/src/preview-text/index.tsx
@@ -57,9 +57,9 @@ const Select: React.FC<SelectProps<any>> = (props) => {
       }
     } else {
       if (props.labelInValue) {
-        return value ? [value] : []
+        return isValid(value) ? [value] : []
       } else {
-        return value ? [{ label: value, value }] : []
+        return isValid(value) ? [{ label: value, value }] : []
       }
     }
   }

--- a/packages/next/src/preview-text/index.tsx
+++ b/packages/next/src/preview-text/index.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react'
-import { isArr, isEmpty } from '@formily/shared'
+import { isArr, isEmpty, isValid } from '@formily/shared'
 import { useField } from '@formily/react'
 import { InputProps } from '@alifd/next/lib/input'
 import { SelectProps } from '@alifd/next/lib/select'
@@ -57,9 +57,9 @@ const Select: React.FC<SelectProps> = (props) => {
       }
     } else {
       if (props.useDetailValue) {
-        return value ? [value] : []
+        return isValid(value) ? [value] : []
       } else {
-        return value ? [{ label: value, value }] : []
+        return isValid(value) ? [{ label: value, value }] : []
       }
     }
   }


### PR DESCRIPTION
#1296: Fix that `false` value (and corresponding label) is displayed as `'N/A'` in `PreviewText.Select`

