### PR TITLE
fix: incorrect generated dts in useFieldSchema

### DIFF
--- a/packages/react/src/hooks/useFieldSchema.ts
+++ b/packages/react/src/hooks/useFieldSchema.ts
@@ -1,6 +1,7 @@
 import { useContext } from 'react'
 import { SchemaContext } from '../shared'
+import { Schema } from '@formily/json-schema'
 
-export const useFieldSchema = () => {
+export const useFieldSchema = (): Schema => {
   return useContext(SchemaContext)
 }


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

The generated dts file of `@formily/react@2.0.0-rc.17` is incorrect because it has a module reference to `package/json-schema/esm`, which cannot be found outside the main monorepo project of formily.

```ts
export declare const useFieldSchema: () => import("packages/json-schema/esm").Schema<any, any, any, any, any, any, any, any, any>;
```

This PR changes the module reference to `@formily/json-schema`.

```ts
import { Schema } from '@formily/json-schema';
export declare const useFieldSchema: () => Schema;
```