### PR TITLE
fix(core): make exchangeArrayState be right when move

### DIFF
--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -422,13 +422,25 @@ export const exchangeArrayState = (
   const isArrayChildren = (identifier: string) => {
     return identifier.indexOf(address) === 0 && identifier.length > addrLength
   }
+  
+  const isDown = fromIndex < toIndex;
 
-  const isFromOrToNode = (identifier: string) => {
+  const isMoveNode = (identifier: string) => {
+    const afterStr = identifier.slice(address.length);
+    const number = afterStr.match(NumberIndexReg)?.[1];
+    if (number === undefined) return false;
+    const index = Number(number);
+    return isDown
+      ? index > fromIndex && index <= toIndex
+      : index < fromIndex && index >= toIndex;
+  };
+
+  const isFromNode = (identifier: string) => {
     const afterStr = identifier.substring(addrLength)
     const number = afterStr.match(NumberIndexReg)?.[1]
     if (number === undefined) return false
     const index = Number(number)
-    return index === toIndex || index === fromIndex
+    return index === fromIndex
   }
 
   const moveIndex = (identifier: string) => {
@@ -440,7 +452,7 @@ export const exchangeArrayState = (
     if (index === fromIndex) {
       index = toIndex
     } else {
-      index = fromIndex
+      index += isDown ? -1 : 1;
     }
 
     return `${preStr}${afterStr.replace(/^\.\d+/, `.${index}`)}`
@@ -449,7 +461,7 @@ export const exchangeArrayState = (
   batch(() => {
     each(fields, (field, identifier) => {
       if (isArrayChildren(identifier)) {
-        if (isFromOrToNode(identifier)) {
+        if (isMoveNode(identifier) || isFromNode(identifier)) {
           const newIdentifier = moveIndex(identifier)
           fieldPatches.push({
             type: 'update',


### PR DESCRIPTION
移动 0 -> 3，需要将 0 -> 3，以及将 3 -> 2，2 -> 1，1 -> 0，目前 ArrayField.value 是这么做的，但是 form.fields 没有这么做。

_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
