### PR TITLE
fix(reactive-vue): stop tracking if vm is destroyed #3074

### DIFF
--- a/packages/reactive-vue/src/__tests__/observer.spec.ts
+++ b/packages/reactive-vue/src/__tests__/observer.spec.ts
@@ -118,3 +118,34 @@ test('observer: component scheduler', async () => {
 
   wrapper.destroy()
 })
+
+test('observer: stop tracking if watcher is destroyed', async () => {
+  let count = 0
+  const model = observable<any>({
+    age: 10,
+    name: 'test',
+  })
+
+  const Component = observer({
+    name: 'test',
+    data() {
+      return {
+        model: model,
+      }
+    },
+    render() {
+      count++
+      return h('div', [this.model.name, this.model.age])
+    },
+  })
+
+  const wrapper = shallowMount(Component)
+
+  const childInst = wrapper.find({ name: 'test' })
+
+  expect(childInst.exists()).toBe(true)
+  ;(childInst.vm as any)._isDestroyed = true
+  model.age++
+  wrapper.destroy()
+  expect(count).toEqual(1) // 不触发 reactiveRender
+})

--- a/packages/reactive-vue/src/observer/observerInVue2.ts
+++ b/packages/reactive-vue/src/observer/observerInVue2.ts
@@ -69,7 +69,16 @@ function observer(Component: any, observerOptions?: IObserverOptions): any {
       return this
     }
 
+    reactiveRender.$vm = this
+
     const tracker = new Tracker(() => {
+      if (
+        reactiveRender.$vm._isBeingDestroyed ||
+        reactiveRender.$vm._isDestroyed
+      ) {
+        return tracker.dispose()
+      }
+
       if (
         observerOptions?.scheduler &&
         typeof observerOptions.scheduler === 'function'


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [ ] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
在执行 reactiveRender 前判断一下绑定的 vue 实例是否已经被销毁，避免出现意料之外的依赖收集