### PR TITLE
fix(vue): fix reactions not work correctly in schema field

### DIFF
--- a/packages/vue/src/components/RecursionField.ts
+++ b/packages/vue/src/components/RecursionField.ts
@@ -13,12 +13,13 @@ import ArrayField from './ArrayField'
 import Field from './Field'
 import VoidField from './VoidField'
 import { h } from '../shared/h'
-import { Fragment } from '../shared/fragment'
 
 import type { IRecursionFieldProps, DefineComponent } from '../types'
 
 const resolveEmptySlot = (slots: Record<any, (...args: any[]) => any[]>) => {
-  return Object.keys(slots).length ? h(Fragment, {}, slots) : undefined
+  return Object.keys(slots).length
+    ? h('div', { style: 'display:contents;' }, slots)
+    : undefined
 }
 
 const RecursionField = {

--- a/packages/vue/src/shared/h.ts
+++ b/packages/vue/src/shared/h.ts
@@ -6,7 +6,6 @@ type RenderChildren = {
   [key in string]?: (...args: any[]) => (VNode | string)[]
 }
 
-// TODO: need to compatible with vue2 & vue3
 type Tag = any
 type VNodeData = Record<string, any>
 type VNode = any


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

该PR影响的场景，当SchemaField作为某组件子元素时，外层会比之前多一个 display:contents 的 div 元素(替换了原本产生问题的Fragment组件)，对于某些会检测子元素个数的父组件会有影响。例如:

``` html
<FormProvider :form="form">
  <FormGrid>
    <SchemaField :schema="schema" />
    <OtherFields />
  </FormGrid>
</FormProvider>
```
FormGrid 会根据子元素个数给定不同的默认值，在以上场景，手动设置 minColumns 等属性可保证前后表现一致。
