### PR TITLE
fix(react): update type of IRecursionFieldProps

### DIFF
--- a/packages/react/docs/api/components/RecursionField.md
+++ b/packages/react/docs/api/components/RecursionField.md
@@ -12,7 +12,7 @@ The recursive rendering component is mainly based on [JSON-Schema](/api/shared/s
 
 ```ts
 interface IRecursionFieldProps {
-  schema: Schema //schema object
+  schema: ISchema //Field schema
   name?: string //Path name
   basePath?: FormPathPattern //base path
   onlyRenderProperties?: boolean //Whether to only render properties

--- a/packages/react/docs/api/components/RecursionField.zh-CN.md
+++ b/packages/react/docs/api/components/RecursionField.zh-CN.md
@@ -12,7 +12,7 @@ order: 5
 
 ```ts
 interface IRecursionFieldProps {
-  schema: Schema //schema对象
+  schema: ISchema //字段schema
   name?: string //路径名称
   basePath?: FormPathPattern //基础路径
   onlyRenderProperties?: boolean //是否只渲染properties

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -96,7 +96,7 @@ export interface ISchemaFilter {
   (schema: Schema, name: SchemaKey): boolean
 }
 export interface IRecursionFieldProps {
-  schema: Schema
+  schema: ISchema
   name?: SchemaKey
   basePath?: FormPathPattern
   onlyRenderProperties?: boolean


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

根据 RecursionField 的可扩展性将 IRecursionFieldProps 中的 schema 类型从 Schema 改为 ISchema。

改完之后文档中的[这个例子](https://react.formilyjs.org/zh-CN/api/components/recursion-field#%E7%AE%80%E5%8D%95%E9%80%92%E5%BD%92)类型应该就不会报错了。


有两个小问题：

1. 用 `npm run test:react` 测试跑不通，貌似是 `@testing-library/react` 的版本太低了。不过我只改了类型和文档没改逻辑应该不影响测试结果
2. 本来想把 vue 的部分也一起改了的，但是看文档稍微有点老，类型也有些冗余啥的，怕在不了解的情况下玩坏了就没动
