### PR TITLE
fix(element): update type of IFormDialog

### DIFF
--- a/packages/element/docs/guide/form-dialog.md
+++ b/packages/element/docs/guide/form-dialog.md
@@ -51,9 +51,18 @@ type IFormDialogProps = Omit<DialogProps, 'title'> & {
 }
 
 interface IFormDialog {
-  forOpen(middleware: IMiddleware<IFormProps>): IFormDialog
-  forConfirm(middleware: IMiddleware<IFormProps>): IFormDialog
-  forCancel(middleware: IMiddleware<IFormProps>): IFormDialog
+  forOpen(
+    middleware: (
+      props: IFormProps,
+      next: (props?: IFormProps) => Promise<any>
+    ) => any
+  ): IFormDialog
+  forConfirm(
+    middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
+  ): IFormDialog
+  forCancel(
+    middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
+  ): IFormDialog
   open(props?: IFormProps): Promise<any>
   close(): void
 }

--- a/packages/element/src/form-dialog/index.ts
+++ b/packages/element/src/form-dialog/index.ts
@@ -65,8 +65,8 @@ const getDialogProps = (props: any): IFormDialogProps => {
 
 export interface IFormDialog {
   forOpen(middleware: IMiddleware<IFormProps>): IFormDialog
-  forConfirm(middleware: IMiddleware<IFormProps>): IFormDialog
-  forCancel(middleware: IMiddleware<IFormProps>): IFormDialog
+  forConfirm(middleware: IMiddleware<Form>): IFormDialog
+  forCancel(middleware: IMiddleware<Form>): IFormDialog
   open(props?: IFormProps): Promise<any>
   close(): void
 }


### PR DESCRIPTION
1. 经检查下面的函数实现，IFormDialog中forConfirm、forCancel的参数middleware的类型IMiddleware泛型应为Form而不是IFormProps
2. 更正对应的文档，并参照antd/FormDialog优化，使文档中的类型定义更清晰。

_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
