### PR TITLE
fix(next/antd): fix moment format

### DIFF
--- a/packages/antd/__tests__/moment.spec.ts
+++ b/packages/antd/__tests__/moment.spec.ts
@@ -30,6 +30,15 @@ test('formatMomentValue is usable', () => {
     moment(1663155911097).format('YYYY-MM-DD HH:mm:ss'),
   ])
   expect(
+    formatMomentValue('2022-09-15T09:56:26.000Z', 'YYYY-MM-DD HH:mm:ss')
+  ).toEqual('2022-09-15 17:56:26')
+  expect(
+    formatMomentValue(['2022-09-15T09:56:26.000Z'], ['YYYY-MM-DD HH:mm:ss'])
+  ).toEqual(['2022-09-15 17:56:26'])
+  expect(formatMomentValue('2022-09-15 09:56:26', 'HH:mm:ss')).toEqual(
+    '09:56:26'
+  )
+  expect(
     formatMomentValue(
       ['2021-12-21 15:47:00', '2021-12-29 15:47:00'],
       'YYYY-MM-DD'

--- a/packages/antd/src/__builtins__/moment.ts
+++ b/packages/antd/src/__builtins__/moment.ts
@@ -24,7 +24,7 @@ export const formatMomentValue = (
       if (isEmpty(_format)) {
         return date
       }
-      if (typeof date === 'number') {
+      if (typeof date === 'number' || date.length !== _format.length) {
         return moment(date).format(_format)
       }
       return moment(date, _format).format(_format)
@@ -35,7 +35,7 @@ export const formatMomentValue = (
       if (isEmpty(format)) {
         return date
       }
-      if (typeof date === 'number') {
+      if (typeof date === 'number' || date.length !== format.length) {
         return moment(date).format(format)
       }
       return moment(date, format).format(format)

--- a/packages/next/__tests__/moment.spec.ts
+++ b/packages/next/__tests__/moment.spec.ts
@@ -30,6 +30,15 @@ test('formatMomentValue is usable', () => {
     moment(1663155911097).format('YYYY-MM-DD HH:mm:ss'),
   ])
   expect(
+    formatMomentValue('2022-09-15T09:56:26.000Z', 'YYYY-MM-DD HH:mm:ss')
+  ).toEqual('2022-09-15 17:56:26')
+  expect(
+    formatMomentValue(['2022-09-15T09:56:26.000Z'], ['YYYY-MM-DD HH:mm:ss'])
+  ).toEqual(['2022-09-15 17:56:26'])
+  expect(formatMomentValue('2022-09-15 09:56:26', 'HH:mm:ss')).toEqual(
+    '09:56:26'
+  )
+  expect(
     formatMomentValue(
       ['2021-12-21 15:47:00', '2021-12-29 15:47:00'],
       'YYYY-MM-DD'

--- a/packages/next/src/__builtins__/moment.ts
+++ b/packages/next/src/__builtins__/moment.ts
@@ -28,7 +28,7 @@ export const formatMomentValue = (
       if (isEmpty(_format)) {
         return date
       }
-      if (typeof date === 'number') {
+      if (typeof date === 'number' || date.length !== _format.length) {
         return moment(date).format(_format)
       }
       return moment(date, _format).format(_format)
@@ -39,7 +39,7 @@ export const formatMomentValue = (
       if (isEmpty(format)) {
         return date
       }
-      if (typeof date === 'number') {
+      if (typeof date === 'number' || date.length !== format.length) {
         return moment(date).format(format)
       }
       return moment(date, format).format(format)


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
fix(next): fix time format moment (https://github.com/alibaba/formily/pull/3330)
在之前这个pr中，把原有的可以转换日期格式的能力给弄丢了，变成前后的格式必须一致的情况，导致历史代码出错，可以看我加的3个测试case，求大佬修复