### PR TITLE
feat(antd/next/element): cancel FormDialog loading status by next(false)

### DIFF
--- a/packages/antd/docs/components/FormDialog.md
+++ b/packages/antd/docs/components/FormDialog.md
@@ -322,8 +322,11 @@ interface IFormDialog {
     ) => any
   ): any //Middleware interceptor, can intercept Dialog to open
   forConfirm(
-    middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
-  ): any //Middleware interceptor, which can intercept Dialog confirmation
+    middleware: (
+      props: Form,
+      next: (props?: Form | false) => Promise<any>
+    ) => any
+  ): any //Middleware interceptor, which can intercept Dialog confirmation. Pass in false to next() to cancel loading status only, instead of close Dialog.
   forCancel(
     middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
   ): any //Middleware interceptor, can intercept Dialog to cancel

--- a/packages/antd/docs/components/FormDialog.zh-CN.md
+++ b/packages/antd/docs/components/FormDialog.zh-CN.md
@@ -331,8 +331,11 @@ interface IFormDialog {
     ) => any
   ): any //中间件拦截器，可以拦截Dialog打开
   forConfirm(
-    middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
-  ): any //中间件拦截器，可以拦截Dialog确认
+    middleware: (
+      props: Form,
+      next: (props?: Form | false) => Promise<any>
+    ) => any
+  ): any //中间件拦截器，可以拦截Dialog确认，next传入false可以仅取消提交按钮的loading状态而不关闭Dialog
   forCancel(
     middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
   ): any //中间件拦截器，可以拦截Dialog取消

--- a/packages/antd/src/form-dialog/index.tsx
+++ b/packages/antd/src/form-dialog/index.tsx
@@ -43,7 +43,7 @@ const getModelProps = (props: any): IModalProps => {
 
 export interface IFormDialog {
   forOpen(middleware: IMiddleware<IFormProps>): IFormDialog
-  forConfirm(middleware: IMiddleware<Form>): IFormDialog
+  forConfirm(middleware: IMiddleware<Form | false>): IFormDialog
   forCancel(middleware: IMiddleware<Form>): IFormDialog
   open(props?: IFormProps): Promise<any>
   close(): void
@@ -167,9 +167,14 @@ export function FormDialog(title: any, id: any, renderer?: any): IFormDialog {
             () => {
               env.form
                 .submit(async () => {
-                  await applyMiddleware(env.form, env.confirmMiddlewares)
+                  const result = await applyMiddleware(
+                    env.form,
+                    env.confirmMiddlewares
+                  )
                   resolve(toJS(env.form.values))
-                  formDialog.close()
+                  if (result !== false) {
+                    formDialog.close()
+                  }
                 })
                 .catch(() => {})
             },

--- a/packages/element/docs/guide/form-dialog.md
+++ b/packages/element/docs/guide/form-dialog.md
@@ -58,7 +58,10 @@ interface IFormDialog {
     ) => any
   ): IFormDialog
   forConfirm(
-    middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
+    middleware: (
+      props: Form,
+      next: (props?: Form | false) => Promise<any>
+    ) => any
   ): IFormDialog
   forCancel(
     middleware: (props: Form, next: (props?: Form) => Promise<any>) => any

--- a/packages/element/src/form-dialog/index.ts
+++ b/packages/element/src/form-dialog/index.ts
@@ -65,8 +65,8 @@ const getDialogProps = (props: any): IFormDialogProps => {
 
 export interface IFormDialog {
   forOpen(middleware: IMiddleware<IFormProps>): IFormDialog
-  forConfirm(middleware: IMiddleware<Form>): IFormDialog
-  forCancel(middleware: IMiddleware<Form>): IFormDialog
+  forConfirm(middleware: IMiddleware<IFormProps | false>): IFormDialog
+  forCancel(middleware: IMiddleware<IFormProps>): IFormDialog
   open(props?: IFormProps): Promise<any>
   close(): void
 }
@@ -348,8 +348,14 @@ export function FormDialog(
           () => {
             env.form
               .submit(async () => {
-                await applyMiddleware(env.form, env.confirmMiddlewares)
+                const result = await applyMiddleware(
+                  env.form,
+                  env.confirmMiddlewares
+                )
                 resolve(toJS(env.form.values))
+                if (result === false) {
+                  return
+                }
                 if (dialogProps.beforeClose) {
                   setTimeout(() => {
                     dialogProps.beforeClose(() => {

--- a/packages/next/docs/components/FormDialog.md
+++ b/packages/next/docs/components/FormDialog.md
@@ -311,8 +311,11 @@ interface IFormDialog {
     ) => any
   ): any //Middleware interceptor, can intercept Dialog to open
   forConfirm(
-    middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
-  ): any //Middleware interceptor, which can intercept Dialog confirmation
+    middleware: (
+      props: Form,
+      next: (props?: Form | false) => Promise<any>
+    ) => any
+  ): any //Middleware interceptor, which can intercept Dialog confirmation. Pass in false to next() to cancel loading status only, instead of close Dialog.
   forCancel(
     middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
   ): any //Middleware interceptor, can intercept Dialog to cancel

--- a/packages/next/docs/components/FormDialog.zh-CN.md
+++ b/packages/next/docs/components/FormDialog.zh-CN.md
@@ -340,8 +340,11 @@ interface IFormDialog {
     ) => any
   ): any //中间件拦截器，可以拦截Dialog打开
   forConfirm(
-    middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
-  ): any //中间件拦截器，可以拦截Dialog确认
+    middleware: (
+      props: Form,
+      next: (props?: Form | false) => Promise<any>
+    ) => any
+  ): any //中间件拦截器，可以拦截Dialog确认，next传入false可以仅取消提交按钮的loading状态而不关闭Dialog
   forCancel(
     middleware: (props: Form, next: (props?: Form) => Promise<any>) => any
   ): any //中间件拦截器，可以拦截Dialog取消

--- a/packages/next/src/form-dialog/index.tsx
+++ b/packages/next/src/form-dialog/index.tsx
@@ -52,7 +52,7 @@ export interface IDialogProps extends DialogProps {
 
 export interface IFormDialog {
   forOpen(middleware: IMiddleware<IFormProps>): IFormDialog
-  forConfirm(middleware: IMiddleware<Form>): IFormDialog
+  forConfirm(middleware: IMiddleware<Form | false>): IFormDialog
   forCancel(middleware: IMiddleware<Form>): IFormDialog
   open(props?: IFormProps): Promise<any>
   close(): void
@@ -216,9 +216,14 @@ export function FormDialog(title: any, id: any, renderer?: any): IFormDialog {
             () => {
               env.form
                 .submit(async () => {
-                  await applyMiddleware(env.form, env.confirmMiddlewares)
+                  const result = await applyMiddleware(
+                    env.form,
+                    env.confirmMiddlewares
+                  )
                   resolve(toJS(env.form.values))
-                  formDialog.close()
+                  if (result !== false) {
+                    formDialog.close()
+                  }
                 })
                 .catch(() => {})
             },


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
1. FormDialog一种常见的使用场景是，表单提交后需要服务端做校验决定是否成功(如：某些需要唯一的参数code、唯一用户名等等)，成功则关闭Dialog，失败则保留Dialog，仅关闭loading状态并Toast提示用户失败原因。现有FormDialog实现不调用next则无法关闭loading状态，调用next则会关闭Dialog，无法满足仅关闭loading状态不关闭Dialog的需求。
2. 通过判断next传递的参数是否严格等于false，可以满足需求，并且兼容历史代码（如使用next()，undefined === false 为 false，仍然能按预期关闭弹窗）
