### PR TITLE
fix(antd): fix ArrayTable WrapperComp deps missing

### DIFF
--- a/packages/antd/src/array-table/index.tsx
+++ b/packages/antd/src/array-table/index.tsx
@@ -332,7 +332,7 @@ export const ArrayTable: ComposedArrayTable = observer(
           {...props}
         />
       ),
-      []
+      [field]
     )
 
     return (


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
Fixed #3454
Function `WrapperComp` of `<ArrayTable>` missing dependence `field`, lead to move fn called by a wrong field instance.