### PR TITLE
fix(core): fix value filtered from none-hidden  #3477

### DIFF
--- a/packages/core/src/__tests__/field.spec.ts
+++ b/packages/core/src/__tests__/field.spec.ts
@@ -2298,7 +2298,7 @@ test('field actions', () => {
 
 test('field hidden value', () => {
   const form = attach(createForm())
-  attach(
+  const aa = attach(
     form.createField({
       name: 'aa',
       hidden: true,
@@ -2306,4 +2306,31 @@ test('field hidden value', () => {
     })
   )
   expect(form.values).toEqual({ aa: '123' })
+
+  const objectField = attach(
+    form.createObjectField({
+      name: 'object',
+      hidden: true,
+    })
+  )
+  const arrayField = attach(
+    form.createArrayField({
+      name: 'array',
+      hidden: true,
+    })
+  )
+
+  aa.setDisplay('none')
+  objectField.setDisplay('none')
+  arrayField.setDisplay('none')
+  expect(aa.value).toBeUndefined()
+  expect(objectField.value).toBeUndefined()
+  expect(arrayField.value).toBeUndefined()
+
+  aa.setDisplay('hidden')
+  objectField.setDisplay('hidden')
+  arrayField.setDisplay('hidden')
+  expect(aa.value).toEqual('123')
+  expect(objectField.value).toEqual({})
+  expect(arrayField.value).toEqual([])
 })

--- a/packages/core/src/models/Field.ts
+++ b/packages/core/src/models/Field.ts
@@ -245,16 +245,14 @@ export class Field<
         () => this.display,
         (display) => {
           const value = this.value
-          if (display === 'visible') {
-            if (isEmpty(value)) {
+          if (display !== 'none') {
+            if (!isValid(value)) {
               this.setValue(this.caches.value)
               this.caches.value = undefined
             }
           } else {
             this.caches.value = toJS(value) ?? toJS(this.initialValue)
-            if (display === 'none') {
-              this.form.deleteValuesIn(this.path)
-            }
+            this.form.deleteValuesIn(this.path)
           }
           if (display === 'none' || display === 'hidden') {
             this.setFeedback({

--- a/packages/core/src/models/Field.ts
+++ b/packages/core/src/models/Field.ts
@@ -1,10 +1,4 @@
-import {
-  isValid,
-  isEmpty,
-  toArr,
-  FormPathPattern,
-  isArr,
-} from '@formily/shared'
+import { isValid, toArr, FormPathPattern, isArr } from '@formily/shared'
 import {
   ValidatorTriggerType,
   parseValidatorDescriptions,


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
Fix #3477

1.当 `field.display` 从 `none` 变为 `hidden` 时，不会触发 `this.setValue(this.caches.value)`，导致field的值不会被更新。修改了判断条件以修复问题。
2. 使用`isEmpty`做判断会导致 field.value 为 `{}` 时，会被当做空而跳过恢复缓存值。故更换为 `!isValid()`进行判断
3. 增加了针对上述case的单测

