### PR TITLE
fix(vue): keep origin SlotProps pass in ReactiveField

### DIFF
--- a/packages/vue/src/components/ReactiveField.ts
+++ b/packages/vue/src/components/ReactiveField.ts
@@ -69,8 +69,11 @@ const mergeSlots = (
       }
     }
   }
-  const patchSlot = (slotName: string) => () =>
-    slots[slotName]?.({ field, form: field.form }) ?? []
+  const patchSlot =
+    (slotName: string) =>
+    (originSlotScope: Record<string, any> = {}) =>
+      slots[slotName]?.({ field, form: field.form, ...originSlotScope }) ?? []
+
   const patchedSlots: Record<string, (...args: any) => unknown[]> = {}
   slotNames.forEach((name) => {
     patchedSlots[name] = patchSlot(name)


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

keep origin slot params transmit in ReactiveField