### PR TITLE
fix(element): fix Checkbox.Group's change event failure

### DIFF
--- a/packages/element/src/checkbox/index.ts
+++ b/packages/element/src/checkbox/index.ts
@@ -85,6 +85,7 @@ export type CheckboxGroupProps = ElCheckboxGroupProps & {
 
 const TransformElCheckboxGroup = transformComponent(ElCheckboxGroup, {
   change: 'input',
+  uselessChange: 'change'
 })
 
 const CheckboxGroupOption = defineComponent<CheckboxGroupProps>({


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [ ] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
fix Checkbox.Group's change event is triggered twice, Cause functional failure. 
修复多选框组选项勾选失败问题。
## 具体原因
`Checkbox.Group`组件一次点击而触发两次 `change` 事件并且两次chang事件获得的值不一致，所以导致切换失败。 可以参考 #3665 。
