### PR TITLE
fix(core): fix  cannot set value after display none

### DIFF
--- a/packages/core/src/__tests__/field.spec.ts
+++ b/packages/core/src/__tests__/field.spec.ts
@@ -150,6 +150,20 @@ test('field display and value', () => {
   expect(objectField.value).toEqual({ value: '123' })
   expect(arrayField.value).toEqual(['123'])
   expect(valueField.value).toEqual('123')
+
+  objectField.visible = false
+  arrayField.visible = false
+  valueField.visible = false
+  objectField.setValue(undefined)
+  arrayField.setValue(undefined)
+  valueField.setValue(undefined)
+
+  objectField.visible = true
+  arrayField.visible = true
+  valueField.visible = true
+  expect(objectField.value).toBeUndefined()
+  expect(arrayField.value).toBeUndefined()
+  expect(valueField.value).toBeUndefined()
 })
 
 test('nested display/pattern', () => {

--- a/packages/core/src/models/Field.ts
+++ b/packages/core/src/models/Field.ts
@@ -416,9 +416,12 @@ export class Field<
 
   setValue = (value?: ValueType) => {
     if (this.destroyed) return
+    const displayNone = this.display === 'none'
+    if (displayNone) {
+      this.caches.value = value
+    }
     if (!this.initialized) {
-      if (this.display === 'none') {
-        this.caches.value = value
+      if (displayNone) {
         return
       }
       value = getValidFieldDefaultValue(value, this.initialValue)


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [ ] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

1.当 field.display 从 visible 变为 none 时，修改value，会将当前的value保存到caches.value中，当field.display变为visible的时候，会使用修改后的value，而不是 field.display 从 visible 变为 none 之前的value。
2. 增加了针对上述case的单测
