### PR TITLE
feat(antd): FormItem adds more attribute configuration

### DIFF
--- a/packages/antd/docs/components/FormItem.md
+++ b/packages/antd/docs/components/FormItem.md
@@ -324,6 +324,28 @@ export default () => {
             wrapperCol: 10,
           }}
         />
+        <SchemaField.String
+          title="Required mark style(hidden)"
+          x-decorator="FormItem"
+          x-component="Input"
+          required
+          x-decorator-props={{
+            requiredMark: false,
+            labelCol: 6,
+            wrapperCol: 10,
+          }}
+        />
+        <SchemaField.String
+          title="Required mark style(optional)"
+          x-decorator="FormItem"
+          x-component="Input"
+          required
+          x-decorator-props={{
+            requiredMark: 'optional',
+            labelCol: 6,
+            wrapperCol: 10,
+          }}
+        />
 
         <SchemaField.String
           title="prefix"
@@ -721,6 +743,17 @@ export default () => {
           }}
         />
 
+        <SchemaField.String
+          title="Status border style disabled(feedbackStatus=error)"
+          x-decorator="FormItem"
+          x-component="Input"
+          description="description"
+          x-decorator-props={{
+            enableOutlineFeedback: false,
+            feedbackStatus: 'error',
+          }}
+        />
+
         <SchemaField.Void
           x-component="Title"
           x-component-props={{ text: 'Layout of feedback information' }}
@@ -1058,39 +1091,41 @@ export default () => {
 
 ### FormItem
 
-| Property name     | Type                                                   | Description                                                                                                              | Default value       |
-| ----------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ------------------- |
-| label             | ReactNode                                              | label                                                                                                                    | -                   |
-| style             | CSSProperties                                          | Style                                                                                                                    | -                   |
-| labelStyle        | CSSProperties                                          | Label style                                                                                                              | -                   |
-| wrapperStyle      | CSSProperties                                          | Component container style                                                                                                | -                   |
-| className         | string                                                 | Component style class name                                                                                               | -                   |
-| colon             | boolean                                                | colon                                                                                                                    | true                |
-| tooltip           | ReactNode                                              | Question mark prompt                                                                                                     | -                   |
-| tooltipLayout     | `"icon" \| "text"`                                     | Ask the prompt layout                                                                                                    | `"icon"`            |
-| tooltipIcon       | ReactNode                                              | Ask the prompt icon                                                                                                      | `?`                 |
-| labelAlign        | `"left"` \| `"right"`                                  | Label text alignment                                                                                                     | `"right"`           |
-| labelWrap         | boolean                                                | Label change, otherwise an ellipsis appears, hover has tooltip                                                           | false               |
-| labelWidth        | `number \| string`                                     | Label fixed width                                                                                                        | -                   |
-| wrapperWidth      | `number \| string`                                     | Content fixed width                                                                                                      | -                   |
-| labelCol          | number                                                 | The number of columns occupied by the label grid, and the number of content columns add up to 24                         | -                   |
-| wrapperCol        | number                                                 | The number of columns occupied by the content grid, and the number of label columns add up to 24                         | -                   |
-| wrapperAlign      | `"left"` \| `"right"`                                  | Content text alignment                                                                                                   | `"left"`            |
-| wrapperWrap       | boolean                                                | Change the content, otherwise an ellipsis appears, and hover has tooltip                                                 | false               |
-| fullness          | boolean                                                | fullness                                                                                                                 | false               |
-| addonBefore       | ReactNode                                              | Prefix content                                                                                                           | -                   |
-| addonAfter        | ReactNode                                              | Suffix content                                                                                                           | -                   |
-| size              | `"small"` \| `"default"` \| `"large"`                  | size                                                                                                                     | -                   |
-| inset             | boolean                                                | Is it an inline layout                                                                                                   | false               |
-| extra             | ReactNode                                              | Extended description script                                                                                              | -                   |
-| feedbackText      | ReactNode                                              | Feedback Case                                                                                                            | -                   |
-| feedbackLayout    | `"loose"` \| `"terse"` \| `"popover" \| "none"`        | Feedback layout                                                                                                          | -                   |
-| feedbackStatus    | `"error"` \| `"warning"` \| `"success"` \| `"pending"` | Feedback layout                                                                                                          | -                   |
-| feedbackIcon      | ReactNode                                              | Feedback icon                                                                                                            | -                   |
-| getPopupContainer | function(triggerNode)                                  | when `feedbackLayout` is popover， The DOM container of the tip, the default behavior is to create a div element in body | () => document.body |
-| asterisk          | boolean                                                | Asterisk reminder                                                                                                        | -                   |
-| gridSpan          | number                                                 | Grid layout occupies width                                                                                               | -                   |
-| bordered          | boolean                                                | Is there a border                                                                                                        | -                   |
+| Property name         | Type                                                   | Description                                                                                                                                   | Default value       |
+| --------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| label                 | ReactNode                                              | label                                                                                                                                         | -                   |
+| style                 | CSSProperties                                          | Style                                                                                                                                         | -                   |
+| labelStyle            | CSSProperties                                          | Label style                                                                                                                                   | -                   |
+| wrapperStyle          | CSSProperties                                          | Component container style                                                                                                                     | -                   |
+| className             | string                                                 | Component style class name                                                                                                                    | -                   |
+| colon                 | boolean                                                | colon                                                                                                                                         | true                |
+| tooltip               | ReactNode                                              | Question mark prompt                                                                                                                          | -                   |
+| tooltipLayout         | `"icon" \| "text"`                                     | Ask the prompt layout                                                                                                                         | `"icon"`            |
+| tooltipIcon           | ReactNode                                              | Ask the prompt icon                                                                                                                           | `?`                 |
+| labelAlign            | `"left"` \| `"right"`                                  | Label text alignment                                                                                                                          | `"right"`           |
+| labelWrap             | boolean                                                | Label change, otherwise an ellipsis appears, hover has tooltip                                                                                | false               |
+| labelWidth            | `number \| string`                                     | Label fixed width                                                                                                                             | -                   |
+| wrapperWidth          | `number \| string`                                     | Content fixed width                                                                                                                           | -                   |
+| labelCol              | number                                                 | The number of columns occupied by the label grid, and the number of content columns add up to 24                                              | -                   |
+| wrapperCol            | number                                                 | The number of columns occupied by the content grid, and the number of label columns add up to 24                                              | -                   |
+| wrapperAlign          | `"left"` \| `"right"`                                  | Content text alignment                                                                                                                        | `"left"`            |
+| wrapperWrap           | boolean                                                | Change the content, otherwise an ellipsis appears, and hover has tooltip                                                                      | false               |
+| fullness              | boolean                                                | fullness                                                                                                                                      | false               |
+| addonBefore           | ReactNode                                              | Prefix content                                                                                                                                | -                   |
+| addonAfter            | ReactNode                                              | Suffix content                                                                                                                                | -                   |
+| size                  | `"small"` \| `"default"` \| `"large"`                  | size                                                                                                                                          | -                   |
+| inset                 | boolean                                                | Is it an inline layout                                                                                                                        | false               |
+| extra                 | ReactNode                                              | Extended description script                                                                                                                   | -                   |
+| feedbackText          | ReactNode                                              | Feedback Case                                                                                                                                 | -                   |
+| feedbackLayout        | `"loose"` \| `"terse"` \| `"popover" \| "none"`        | Feedback layout                                                                                                                               | -                   |
+| feedbackStatus        | `"error"` \| `"warning"` \| `"success"` \| `"pending"` | Feedback layout                                                                                                                               | -                   |
+| feedbackIcon          | ReactNode                                              | Feedback icon                                                                                                                                 | -                   |
+| enableOutlineFeedback | boolean                                                | Enable the border color style of the abnormal state, it is recommended to turn off this item when there is a sub-form in the custom component | true                |
+| getPopupContainer     | function(triggerNode)                                  | when `feedbackLayout` is popover， The DOM container of the tip, the default behavior is to create a div element in body                      | () => document.body |
+| asterisk              | boolean                                                | Asterisk reminder                                                                                                                             | -                   |
+| requiredMark          | boolean \| `"optional"`                                | Required mark style. Can use required mark or optional mark                                                                                   | true                |
+| gridSpan              | number                                                 | Grid layout occupies width                                                                                                                    | -                   |
+| bordered              | boolean                                                | Is there a border                                                                                                                             | -                   |
 
 ### FormItem.BaseItem
 

--- a/packages/antd/docs/components/FormItem.md
+++ b/packages/antd/docs/components/FormItem.md
@@ -324,28 +324,6 @@ export default () => {
             wrapperCol: 10,
           }}
         />
-        <SchemaField.String
-          title="Required mark style(hidden)"
-          x-decorator="FormItem"
-          x-component="Input"
-          required
-          x-decorator-props={{
-            requiredMark: false,
-            labelCol: 6,
-            wrapperCol: 10,
-          }}
-        />
-        <SchemaField.String
-          title="Required mark style(optional)"
-          x-decorator="FormItem"
-          x-component="Input"
-          required
-          x-decorator-props={{
-            requiredMark: 'optional',
-            labelCol: 6,
-            wrapperCol: 10,
-          }}
-        />
 
         <SchemaField.String
           title="prefix"
@@ -392,6 +370,61 @@ export default () => {
         />
       </SchemaField>
     </FormProvider>
+  )
+}
+```
+
+## Required style
+
+```tsx
+import React, { useState } from 'react'
+import { Input, FormItem, FormLayout } from '@formily/antd'
+import { Radio } from 'antd'
+import { createForm } from '@formily/core'
+import { FormProvider, createSchemaField } from '@formily/react'
+
+const SchemaField = createSchemaField({
+  components: {
+    Input,
+    FormItem,
+  },
+})
+
+const form = createForm()
+
+export default () => {
+  const [requiredMark, setRequiredMark] = useState(true)
+  return (
+    <div>
+      <p>
+        Required Mark：
+        <Radio.Group
+          value={requiredMark}
+          onChange={(e) => setRequiredMark(e.target.value)}
+        >
+          <Radio.Button value="optional">optional</Radio.Button>
+          <Radio.Button value={true}>true</Radio.Button>
+          <Radio.Button value={false}>false</Radio.Button>
+        </Radio.Group>
+      </p>
+      <FormProvider form={form}>
+        <FormLayout requiredMark={requiredMark}>
+          <SchemaField>
+            <SchemaField.String
+              title="I am Required"
+              required
+              x-decorator="FormItem"
+              x-component="Input"
+            />
+            <SchemaField.String
+              title="I am Optional"
+              x-decorator="FormItem"
+              x-component="Input"
+            />
+          </SchemaField>
+        </FormLayout>
+      </FormProvider>
+    </div>
   )
 }
 ```
@@ -1123,7 +1156,6 @@ export default () => {
 | enableOutlineFeedback | boolean                                                | Enable the border color style of the abnormal state, it is recommended to turn off this item when there is a sub-form in the custom component | true                |
 | getPopupContainer     | function(triggerNode)                                  | when `feedbackLayout` is popover， The DOM container of the tip, the default behavior is to create a div element in body                      | () => document.body |
 | asterisk              | boolean                                                | Asterisk reminder                                                                                                                             | -                   |
-| requiredMark          | boolean \| `"optional"`                                | Required mark style. Can use required mark or optional mark                                                                                   | true                |
 | gridSpan              | number                                                 | Grid layout occupies width                                                                                                                    | -                   |
 | bordered              | boolean                                                | Is there a border                                                                                                                             | -                   |
 

--- a/packages/antd/docs/components/FormItem.zh-CN.md
+++ b/packages/antd/docs/components/FormItem.zh-CN.md
@@ -324,28 +324,6 @@ export default () => {
             wrapperCol: 10,
           }}
         />
-        <SchemaField.String
-          title="必填样式-隐藏"
-          x-decorator="FormItem"
-          x-component="Input"
-          required
-          x-decorator-props={{
-            requiredMark: false,
-            labelCol: 6,
-            wrapperCol: 10,
-          }}
-        />
-        <SchemaField.String
-          title="必填样式-可选"
-          x-decorator="FormItem"
-          x-component="Input"
-          required
-          x-decorator-props={{
-            requiredMark: 'optional',
-            labelCol: 6,
-            wrapperCol: 10,
-          }}
-        />
 
         <SchemaField.String
           title="前缀"
@@ -392,6 +370,61 @@ export default () => {
         />
       </SchemaField>
     </FormProvider>
+  )
+}
+```
+
+## 必填样式
+
+```tsx
+import React, { useState } from 'react'
+import { Input, FormItem, FormLayout } from '@formily/antd'
+import { Radio } from 'antd'
+import { createForm } from '@formily/core'
+import { FormProvider, createSchemaField } from '@formily/react'
+
+const SchemaField = createSchemaField({
+  components: {
+    Input,
+    FormItem,
+  },
+})
+
+const form = createForm()
+
+export default () => {
+  const [requiredMark, setRequiredMark] = useState(true)
+  return (
+    <div>
+      <p>
+        Required Mark：
+        <Radio.Group
+          value={requiredMark}
+          onChange={(e) => setRequiredMark(e.target.value)}
+        >
+          <Radio.Button value="optional">optional</Radio.Button>
+          <Radio.Button value={true}>true</Radio.Button>
+          <Radio.Button value={false}>false</Radio.Button>
+        </Radio.Group>
+      </p>
+      <FormProvider form={form}>
+        <FormLayout requiredMark={requiredMark}>
+          <SchemaField>
+            <SchemaField.String
+              title="我是必填项"
+              required
+              x-decorator="FormItem"
+              x-component="Input"
+            />
+            <SchemaField.String
+              title="我是选填项"
+              x-decorator="FormItem"
+              x-component="Input"
+            />
+          </SchemaField>
+        </FormLayout>
+      </FormProvider>
+    </div>
   )
 }
 ```
@@ -1123,7 +1156,6 @@ export default () => {
 | enableOutlineFeedback | boolean                                                | 开启异常状态的边框颜色样式，当自定义组件内存在子表单时建议关闭此项  | true                |
 | getPopupContainer     | function(triggerNode)                                  | 当 feedbackLayout 为 popover 时，浮层渲染父节点，默认渲染到 body 上 | () => document.body |
 | asterisk              | boolean                                                | 星号提醒                                                            | -                   |
-| requiredMark          | boolean \| `"optional"`                                | 必选样式，可以切换为必选或者可选展示样式                            | true                |
 | gridSpan              | number                                                 | ⽹格布局占宽                                                        | -                   |
 | bordered              | boolean                                                | 是否有边框                                                          | -                   |
 

--- a/packages/antd/docs/components/FormItem.zh-CN.md
+++ b/packages/antd/docs/components/FormItem.zh-CN.md
@@ -379,7 +379,8 @@ export default () => {
 ```tsx
 import React, { useState } from 'react'
 import { Input, FormItem, FormLayout } from '@formily/antd'
-import { Radio } from 'antd'
+import { Radio, ConfigProvider } from 'antd'
+import zhCN from 'antd/es/locale/zh_CN'
 import { createForm } from '@formily/core'
 import { FormProvider, createSchemaField } from '@formily/react'
 
@@ -395,7 +396,7 @@ const form = createForm()
 export default () => {
   const [requiredMark, setRequiredMark] = useState(true)
   return (
-    <div>
+    <ConfigProvider locale={zhCN}>
       <p>
         Required Mark：
         <Radio.Group
@@ -424,7 +425,7 @@ export default () => {
           </SchemaField>
         </FormLayout>
       </FormProvider>
-    </div>
+    </ConfigProvider>
   )
 }
 ```

--- a/packages/antd/docs/components/FormItem.zh-CN.md
+++ b/packages/antd/docs/components/FormItem.zh-CN.md
@@ -324,6 +324,28 @@ export default () => {
             wrapperCol: 10,
           }}
         />
+        <SchemaField.String
+          title="必填样式-隐藏"
+          x-decorator="FormItem"
+          x-component="Input"
+          required
+          x-decorator-props={{
+            requiredMark: false,
+            labelCol: 6,
+            wrapperCol: 10,
+          }}
+        />
+        <SchemaField.String
+          title="必填样式-可选"
+          x-decorator="FormItem"
+          x-component="Input"
+          required
+          x-decorator-props={{
+            requiredMark: 'optional',
+            labelCol: 6,
+            wrapperCol: 10,
+          }}
+        />
 
         <SchemaField.String
           title="前缀"
@@ -721,6 +743,17 @@ export default () => {
           }}
         />
 
+        <SchemaField.String
+          title="禁用错误状态边框样式(feedbackStatus=error)"
+          x-decorator="FormItem"
+          x-component="Input"
+          description="description"
+          x-decorator-props={{
+            enableOutlineFeedback: false,
+            feedbackStatus: 'error',
+          }}
+        />
+
         <SchemaField.Void
           x-component="Title"
           x-component-props={{ text: '反馈信息的布局' }}
@@ -1058,39 +1091,41 @@ export default () => {
 
 ### FormItem
 
-| 属性名            | 类型                                                   | 描述                                                                | 默认值              |
-| ----------------- | ------------------------------------------------------ | ------------------------------------------------------------------- | ------------------- |
-| label             | ReactNode                                              | 标签                                                                | -                   |
-| style             | CSSProperties                                          | 样式                                                                | -                   |
-| labelStyle        | CSSProperties                                          | 标签样式                                                            | -                   |
-| wrapperStyle      | CSSProperties                                          | 组件容器样式                                                        | -                   |
-| className         | string                                                 | 组件样式类名                                                        | -                   |
-| colon             | boolean                                                | 冒号                                                                | true                |
-| tooltip           | ReactNode                                              | 问号提示                                                            | -                   |
-| tooltipLayout     | `"icon" \| "text"`                                     | 问号提示布局                                                        | `"icon"`            |
-| tooltipIcon       | ReactNode                                              | 问号提示图标                                                        | `?`                 |
-| labelAlign        | `"left"` \| `"right"`                                  | 标签文本对齐方式                                                    | `"right"`           |
-| labelWrap         | boolean                                                | 标签换⾏，否则出现省略号，hover 有 tooltip                          | false               |
-| labelWidth        | `number \| string`                                     | 标签固定宽度                                                        | -                   |
-| wrapperWidth      | `number \| string`                                     | 内容固定宽度                                                        | -                   |
-| labelCol          | number                                                 | 标签⽹格所占列数，和内容列数加起来总和为 24                         | -                   |
-| wrapperCol        | number                                                 | 内容⽹格所占列数，和标签列数加起来总和为 24                         | -                   |
-| wrapperAlign      | `"left"` \| `"right"`                                  | 内容文本对齐方式⻬                                                  | `"left"`            |
-| wrapperWrap       | boolean                                                | 内容换⾏，否则出现省略号，hover 有 tooltip                          | false               |
-| fullness          | boolean                                                | 内容撑满                                                            | false               |
-| addonBefore       | ReactNode                                              | 前缀内容                                                            | -                   |
-| addonAfter        | ReactNode                                              | 后缀内容                                                            | -                   |
-| size              | `"small"` \| `"default"` \| `"large"`                  | 尺⼨                                                                | -                   |
-| inset             | boolean                                                | 是否是内嵌布局                                                      | false               |
-| extra             | ReactNode                                              | 扩展描述⽂案                                                        | -                   |
-| feedbackText      | ReactNode                                              | 反馈⽂案                                                            | -                   |
-| feedbackLayout    | `"loose"` \| `"terse"` \| `"popover" \| "none"`        | 反馈布局                                                            | -                   |
-| feedbackStatus    | `"error"` \| `"warning"` \| `"success"` \| `"pending"` | 反馈布局                                                            | -                   |
-| feedbackIcon      | ReactNode                                              | 反馈图标                                                            | -                   |
-| getPopupContainer | function(triggerNode)                                  | 当 feedbackLayout 为 popover 时，浮层渲染父节点，默认渲染到 body 上 | () => document.body |
-| asterisk          | boolean                                                | 星号提醒                                                            | -                   |
-| gridSpan          | number                                                 | ⽹格布局占宽                                                        | -                   |
-| bordered          | boolean                                                | 是否有边框                                                          | -                   |
+| 属性名                | 类型                                                   | 描述                                                                | 默认值              |
+| --------------------- | ------------------------------------------------------ | ------------------------------------------------------------------- | ------------------- |
+| label                 | ReactNode                                              | 标签                                                                | -                   |
+| style                 | CSSProperties                                          | 样式                                                                | -                   |
+| labelStyle            | CSSProperties                                          | 标签样式                                                            | -                   |
+| wrapperStyle          | CSSProperties                                          | 组件容器样式                                                        | -                   |
+| className             | string                                                 | 组件样式类名                                                        | -                   |
+| colon                 | boolean                                                | 冒号                                                                | true                |
+| tooltip               | ReactNode                                              | 问号提示                                                            | -                   |
+| tooltipLayout         | `"icon" \| "text"`                                     | 问号提示布局                                                        | `"icon"`            |
+| tooltipIcon           | ReactNode                                              | 问号提示图标                                                        | `?`                 |
+| labelAlign            | `"left"` \| `"right"`                                  | 标签文本对齐方式                                                    | `"right"`           |
+| labelWrap             | boolean                                                | 标签换⾏，否则出现省略号，hover 有 tooltip                          | false               |
+| labelWidth            | `number \| string`                                     | 标签固定宽度                                                        | -                   |
+| wrapperWidth          | `number \| string`                                     | 内容固定宽度                                                        | -                   |
+| labelCol              | number                                                 | 标签⽹格所占列数，和内容列数加起来总和为 24                         | -                   |
+| wrapperCol            | number                                                 | 内容⽹格所占列数，和标签列数加起来总和为 24                         | -                   |
+| wrapperAlign          | `"left"` \| `"right"`                                  | 内容文本对齐方式⻬                                                  | `"left"`            |
+| wrapperWrap           | boolean                                                | 内容换⾏，否则出现省略号，hover 有 tooltip                          | false               |
+| fullness              | boolean                                                | 内容撑满                                                            | false               |
+| addonBefore           | ReactNode                                              | 前缀内容                                                            | -                   |
+| addonAfter            | ReactNode                                              | 后缀内容                                                            | -                   |
+| size                  | `"small"` \| `"default"` \| `"large"`                  | 尺⼨                                                                | -                   |
+| inset                 | boolean                                                | 是否是内嵌布局                                                      | false               |
+| extra                 | ReactNode                                              | 扩展描述⽂案                                                        | -                   |
+| feedbackText          | ReactNode                                              | 反馈⽂案                                                            | -                   |
+| feedbackLayout        | `"loose"` \| `"terse"` \| `"popover" \| "none"`        | 反馈布局                                                            | -                   |
+| feedbackStatus        | `"error"` \| `"warning"` \| `"success"` \| `"pending"` | 反馈布局                                                            | -                   |
+| feedbackIcon          | ReactNode                                              | 反馈图标                                                            | -                   |
+| enableOutlineFeedback | boolean                                                | 开启异常状态的边框颜色样式，当自定义组件内存在子表单时建议关闭此项  | true                |
+| getPopupContainer     | function(triggerNode)                                  | 当 feedbackLayout 为 popover 时，浮层渲染父节点，默认渲染到 body 上 | () => document.body |
+| asterisk              | boolean                                                | 星号提醒                                                            | -                   |
+| requiredMark          | boolean \| `"optional"`                                | 必选样式，可以切换为必选或者可选展示样式                            | true                |
+| gridSpan              | number                                                 | ⽹格布局占宽                                                        | -                   |
+| bordered              | boolean                                                | 是否有边框                                                          | -                   |
 
 ### FormItem.BaseItem
 

--- a/packages/antd/docs/components/FormLayout.md
+++ b/packages/antd/docs/components/FormLayout.md
@@ -158,30 +158,31 @@ export default () => (
 
 ## API
 
-| Property name  | Type                                                                                   | Description                           | Default value |
-| -------------- | -------------------------------------------------------------------------------------- | ------------------------------------- | ------------- |
-| style          | CSSProperties                                                                          | Style                                 | -             |
-| className      | string                                                                                 | class name                            | -             |
-| colon          | boolean                                                                                | Is there a colon                      | true          |
-| labelAlign     | `'right' \| 'left' \| ('right' \| 'left')[]`                                           | Label content alignment               | -             |
-| wrapperAlign   | `'right' \| 'left' \| ('right' \| 'left')[]`                                           | Component container content alignment | -             |
-| labelWrap      | boolean                                                                                | Wrap label content                    | false         |
-| labelWidth     | number                                                                                 | Label width (px)                      | -             |
-| wrapperWidth   | number                                                                                 | Component container width (px)        | -             |
-| wrapperWrap    | boolean                                                                                | Component container wrap              | false         |
-| labelCol       | `number \| number[]`                                                                   | Label width (24 column)               | -             |
-| wrapperCol     | `number \| number[]`                                                                   | Component container width (24 column) | -             |
-| fullness       | boolean                                                                                | Component container width 100%        | false         |
-| size           | `'small' \|'default' \|'large'`                                                        | component size                        | default       |
-| layout         | `'vertical' \| 'horizontal' \| 'inline' \| ('vertical' \| 'horizontal' \| 'inline')[]` | layout mode                           | horizontal    |
-| direction      | `'rtl' \|'ltr'`                                                                        | direction (not supported yet)         | ltr           |
-| inset          | boolean                                                                                | Inline layout                         | false         |
-| shallow        | boolean                                                                                | shallow context transfer              | true          |
-| feedbackLayout | `'loose' \|'terse' \|'popover' \|'none'`                                               | feedback layout                       | true          |
-| tooltipLayout  | `"icon" \| "text"`                                                                     | Ask the prompt layout                 | `"icon"`      |
-| tooltipIcon    | ReactNode                                                                              | Ask the prompt icon                   | -             |
-| bordered       | boolean                                                                                | Is there a border                     | true          |
-| breakpoints    | number[]                                                                               | Container size breakpoints            | -             |
-| gridColumnGap  | number                                                                                 | Grid Column Gap                       | 8             |
-| gridRowGap     | number                                                                                 | Grid Row Gap                          | 4             |
-| spaceGap       | number                                                                                 | Space Gap                             | 8             |
+| Property name  | Type                                                                                   | Description                                                 | Default value |
+| -------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------- |
+| style          | CSSProperties                                                                          | Style                                                       | -             |
+| className      | string                                                                                 | class name                                                  | -             |
+| colon          | boolean                                                                                | Is there a colon                                            | true          |
+| requiredMark   | boolean \| `"optional"`                                                                | Required mark style. Can use required mark or optional mark | true          |
+| labelAlign     | `'right' \| 'left' \| ('right' \| 'left')[]`                                           | Label content alignment                                     | -             |
+| wrapperAlign   | `'right' \| 'left' \| ('right' \| 'left')[]`                                           | Component container content alignment                       | -             |
+| labelWrap      | boolean                                                                                | Wrap label content                                          | false         |
+| labelWidth     | number                                                                                 | Label width (px)                                            | -             |
+| wrapperWidth   | number                                                                                 | Component container width (px)                              | -             |
+| wrapperWrap    | boolean                                                                                | Component container wrap                                    | false         |
+| labelCol       | `number \| number[]`                                                                   | Label width (24 column)                                     | -             |
+| wrapperCol     | `number \| number[]`                                                                   | Component container width (24 column)                       | -             |
+| fullness       | boolean                                                                                | Component container width 100%                              | false         |
+| size           | `'small' \|'default' \|'large'`                                                        | component size                                              | default       |
+| layout         | `'vertical' \| 'horizontal' \| 'inline' \| ('vertical' \| 'horizontal' \| 'inline')[]` | layout mode                                                 | horizontal    |
+| direction      | `'rtl' \|'ltr'`                                                                        | direction (not supported yet)                               | ltr           |
+| inset          | boolean                                                                                | Inline layout                                               | false         |
+| shallow        | boolean                                                                                | shallow context transfer                                    | true          |
+| feedbackLayout | `'loose' \|'terse' \|'popover' \|'none'`                                               | feedback layout                                             | true          |
+| tooltipLayout  | `"icon" \| "text"`                                                                     | Ask the prompt layout                                       | `"icon"`      |
+| tooltipIcon    | ReactNode                                                                              | Ask the prompt icon                                         | -             |
+| bordered       | boolean                                                                                | Is there a border                                           | true          |
+| breakpoints    | number[]                                                                               | Container size breakpoints                                  | -             |
+| gridColumnGap  | number                                                                                 | Grid Column Gap                                             | 8             |
+| gridRowGap     | number                                                                                 | Grid Row Gap                                                | 4             |
+| spaceGap       | number                                                                                 | Space Gap                                                   | 8             |

--- a/packages/antd/docs/components/FormLayout.zh-CN.md
+++ b/packages/antd/docs/components/FormLayout.zh-CN.md
@@ -164,30 +164,31 @@ export default () => (
 
 ## API
 
-| 属性名         | 类型                                                                                   | 描述                    | 默认值     |
-| -------------- | -------------------------------------------------------------------------------------- | ----------------------- | ---------- |
-| style          | CSSProperties                                                                          | 样式                    | -          |
-| className      | string                                                                                 | 类名                    | -          |
-| colon          | boolean                                                                                | 是否有冒号              | true       |
-| labelAlign     | `'right' \| 'left' \| ('right' \| 'left')[]`                                           | 标签内容对齐            | -          |
-| wrapperAlign   | `'right' \| 'left' \| ('right' \| 'left')[]`                                           | 组件容器内容对齐        | -          |
-| labelWrap      | boolean                                                                                | 标签内容换行            | false      |
-| labelWidth     | number                                                                                 | 标签宽度(px)            | -          |
-| wrapperWidth   | number                                                                                 | 组件容器宽度(px)        | -          |
-| wrapperWrap    | boolean                                                                                | 组件容器换行            | false      |
-| labelCol       | `number \| number[]`                                                                   | 标签宽度(24 column)     | -          |
-| wrapperCol     | `number \| number[]`                                                                   | 组件容器宽度(24 column) | -          |
-| fullness       | boolean                                                                                | 组件容器宽度 100%       | false      |
-| size           | `'small' \| 'default' \| 'large'`                                                      | 组件尺寸                | default    |
-| layout         | `'vertical' \| 'horizontal' \| 'inline' \| ('vertical' \| 'horizontal' \| 'inline')[]` | 布局模式                | horizontal |
-| direction      | `'rtl' \| 'ltr'`                                                                       | 方向(暂不支持)          | ltr        |
-| inset          | boolean                                                                                | 内联布局                | false      |
-| shallow        | boolean                                                                                | 上下文浅层传递          | true       |
-| feedbackLayout | `'loose' \| 'terse' \| 'popover' \| 'none'`                                            | 反馈布局                | true       |
-| tooltipLayout  | `"icon" \| "text"`                                                                     | 问号提示布局            | `"icon"`   |
-| tooltipIcon    | ReactNode                                                                              | 问号提示图标            | -          |
-| bordered       | boolean                                                                                | 是否有边框              | true       |
-| breakpoints    | number[]                                                                               | 容器尺寸断点            | -          |
-| gridColumnGap  | number                                                                                 | 网格布局列间距          | 8          |
-| gridRowGap     | number                                                                                 | 网格布局行间距          | 4          |
-| spaceGap       | number                                                                                 | 弹性间距                | 8          |
+| 属性名         | 类型                                                                                   | 描述                                     | 默认值     |
+| -------------- | -------------------------------------------------------------------------------------- | ---------------------------------------- | ---------- |
+| style          | CSSProperties                                                                          | 样式                                     | -          |
+| className      | string                                                                                 | 类名                                     | -          |
+| colon          | boolean                                                                                | 是否有冒号                               | true       |
+| requiredMark   | boolean \| `"optional"`                                                                | 必选样式，可以切换为必选或者可选展示样式 | true       |
+| labelAlign     | `'right' \| 'left' \| ('right' \| 'left')[]`                                           | 标签内容对齐                             | -          |
+| wrapperAlign   | `'right' \| 'left' \| ('right' \| 'left')[]`                                           | 组件容器内容对齐                         | -          |
+| labelWrap      | boolean                                                                                | 标签内容换行                             | false      |
+| labelWidth     | number                                                                                 | 标签宽度(px)                             | -          |
+| wrapperWidth   | number                                                                                 | 组件容器宽度(px)                         | -          |
+| wrapperWrap    | boolean                                                                                | 组件容器换行                             | false      |
+| labelCol       | `number \| number[]`                                                                   | 标签宽度(24 column)                      | -          |
+| wrapperCol     | `number \| number[]`                                                                   | 组件容器宽度(24 column)                  | -          |
+| fullness       | boolean                                                                                | 组件容器宽度 100%                        | false      |
+| size           | `'small' \| 'default' \| 'large'`                                                      | 组件尺寸                                 | default    |
+| layout         | `'vertical' \| 'horizontal' \| 'inline' \| ('vertical' \| 'horizontal' \| 'inline')[]` | 布局模式                                 | horizontal |
+| direction      | `'rtl' \| 'ltr'`                                                                       | 方向(暂不支持)                           | ltr        |
+| inset          | boolean                                                                                | 内联布局                                 | false      |
+| shallow        | boolean                                                                                | 上下文浅层传递                           | true       |
+| feedbackLayout | `'loose' \| 'terse' \| 'popover' \| 'none'`                                            | 反馈布局                                 | true       |
+| tooltipLayout  | `"icon" \| "text"`                                                                     | 问号提示布局                             | `"icon"`   |
+| tooltipIcon    | ReactNode                                                                              | 问号提示图标                             | -          |
+| bordered       | boolean                                                                                | 是否有边框                               | true       |
+| breakpoints    | number[]                                                                               | 容器尺寸断点                             | -          |
+| gridColumnGap  | number                                                                                 | 网格布局列间距                           | 8          |
+| gridRowGap     | number                                                                                 | 网格布局行间距                           | 4          |
+| spaceGap       | number                                                                                 | 弹性间距                                 | 8          |

--- a/packages/antd/src/form-item/index.tsx
+++ b/packages/antd/src/form-item/index.tsx
@@ -234,7 +234,7 @@ export const BaseItem: React.FC<React.PropsWithChildren<IFormItemProps>> = ({
             <span className={`${prefixCls}-asterisk`}>{'*'}</span>
           )}
           <label>{label}</label>
-          {asterisk && requiredMark === 'optional' && (
+          {!asterisk && requiredMark === 'optional' && (
             <span className={`${prefixCls}-optional`}>（可选）</span>
           )}
         </span>

--- a/packages/antd/src/form-item/index.tsx
+++ b/packages/antd/src/form-item/index.tsx
@@ -5,6 +5,8 @@ import { isVoidField } from '@formily/core'
 import { connect, mapProps } from '@formily/react'
 import { useFormLayout, FormLayoutShallowContext } from '../form-layout'
 import { Tooltip, Popover } from 'antd'
+import { useLocaleReceiver } from 'antd/es/locale-provider/LocaleReceiver'
+import defaultLocale from 'antd/es/locale/default'
 import {
   QuestionCircleOutlined,
   CloseCircleOutlined,
@@ -130,6 +132,7 @@ export const BaseItem: React.FC<React.PropsWithChildren<IFormItemProps>> = ({
 }) => {
   const [active, setActive] = useState(false)
   const formLayout = useFormItemLayout(props)
+  const [formLocale] = useLocaleReceiver('Form')
   const { containerRef, contentRef, overflow } = useOverflow<
     HTMLDivElement,
     HTMLSpanElement
@@ -235,7 +238,7 @@ export const BaseItem: React.FC<React.PropsWithChildren<IFormItemProps>> = ({
           )}
           <label>{label}</label>
           {!asterisk && requiredMark === 'optional' && (
-            <span className={`${prefixCls}-optional`}>（可选）</span>
+            <span className={`${prefixCls}-optional`}>{formLocale?.optional || defaultLocale.Form?.optional}</span>
           )}
         </span>
       </div>

--- a/packages/antd/src/form-item/index.tsx
+++ b/packages/antd/src/form-item/index.tsx
@@ -42,8 +42,10 @@ export interface IFormItemProps {
   feedbackLayout?: 'loose' | 'terse' | 'popover' | 'none' | (string & {})
   feedbackStatus?: 'error' | 'warning' | 'success' | 'pending' | (string & {})
   feedbackIcon?: React.ReactNode
+  enableOutlineFeedback?: boolean
   getPopupContainer?: (node: HTMLElement) => HTMLElement
   asterisk?: boolean
+  requiredMark?: boolean | 'optional'
   gridSpan?: number
   bordered?: boolean
 }
@@ -140,12 +142,14 @@ export const BaseItem: React.FC<React.PropsWithChildren<IFormItemProps>> = ({
     addonBefore,
     addonAfter,
     asterisk,
+    requiredMark = true,
     feedbackStatus,
     extra,
     feedbackText,
     fullness,
     feedbackLayout,
     feedbackIcon,
+    enableOutlineFeedback = true,
     getPopupContainer,
     inset,
     bordered = true,
@@ -226,8 +230,13 @@ export const BaseItem: React.FC<React.PropsWithChildren<IFormItemProps>> = ({
     const labelChildren = (
       <div className={`${prefixCls}-label-content`} ref={containerRef}>
         <span ref={contentRef}>
-          {asterisk && <span className={`${prefixCls}-asterisk`}>{'*'}</span>}
+          {asterisk && requiredMark === true && (
+            <span className={`${prefixCls}-asterisk`}>{'*'}</span>
+          )}
           <label>{label}</label>
+          {asterisk && requiredMark === 'optional' && (
+            <span className={`${prefixCls}-optional`}>（可选）</span>
+          )}
         </span>
       </div>
     )
@@ -290,7 +299,8 @@ export const BaseItem: React.FC<React.PropsWithChildren<IFormItemProps>> = ({
       className={cls({
         [`${prefixCls}`]: true,
         [`${prefixCls}-layout-${layout}`]: true,
-        [`${prefixCls}-${feedbackStatus}`]: !!feedbackStatus,
+        [`${prefixCls}-${feedbackStatus}`]:
+          enableOutlineFeedback && !!feedbackStatus,
         [`${prefixCls}-feedback-has-text`]: !!feedbackText,
         [`${prefixCls}-size-${size}`]: !!size,
         [`${prefixCls}-feedback-layout-${feedbackLayout}`]: !!feedbackLayout,

--- a/packages/antd/src/form-item/index.tsx
+++ b/packages/antd/src/form-item/index.tsx
@@ -45,7 +45,6 @@ export interface IFormItemProps {
   enableOutlineFeedback?: boolean
   getPopupContainer?: (node: HTMLElement) => HTMLElement
   asterisk?: boolean
-  requiredMark?: boolean | 'optional'
   gridSpan?: number
   bordered?: boolean
 }
@@ -76,6 +75,7 @@ const useFormItemLayout = (props: IFormItemProps) => {
     size: props.size ?? layout.size,
     inset: props.inset ?? layout.inset,
     asterisk: props.asterisk,
+    requiredMark: layout.requiredMark,
     bordered: props.bordered ?? layout.bordered,
     feedbackIcon: props.feedbackIcon,
     feedbackLayout: props.feedbackLayout ?? layout.feedbackLayout ?? 'loose',

--- a/packages/antd/src/form-item/style.less
+++ b/packages/antd/src/form-item/style.less
@@ -545,6 +545,10 @@
   font-family: SimSun, sans-serif;
 }
 
+.@{form-item-cls}-optional {
+  color: rgba(0, 0, 0, 0.45);
+}
+
 .@{form-item-cls}-colon {
   margin-left: 2px;
   margin-right: 8px;

--- a/packages/antd/src/form-layout/index.tsx
+++ b/packages/antd/src/form-layout/index.tsx
@@ -8,6 +8,7 @@ export interface IFormLayoutProps {
   className?: string
   style?: React.CSSProperties
   colon?: boolean
+  requiredMark?: boolean | 'optional'
   labelAlign?: 'right' | 'left' | ('right' | 'left')[]
   wrapperAlign?: 'right' | 'left' | ('right' | 'left')[]
   labelWrap?: boolean


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

1. FormItem component adds requiredMark attribute configuration, follow [Antd](https://4x-ant-design.antgroup.com/components/form-cn/#components-form-demo-required-mark) .
2. Added enableOutlineFeedback property configuration for FormItem component. When there is a sub-form in the custom component, the current field verification status will be applied to the sub-form in all range, which is an interactive bug. This kind of scenario can be solved by disabling enableOutlineFeedback.
<img width="1784" alt="image" src="https://user-images.githubusercontent.com/11256006/219592819-ce1bcf3e-ba45-45bb-a9e8-15f45defe60e.png">


