### PR TITLE
fix: formitem antd dep path fix

### DIFF
--- a/packages/antd/src/form-item/index.tsx
+++ b/packages/antd/src/form-item/index.tsx
@@ -5,8 +5,8 @@ import { isVoidField } from '@formily/core'
 import { connect, mapProps } from '@formily/react'
 import { useFormLayout, FormLayoutShallowContext } from '../form-layout'
 import { Tooltip, Popover } from 'antd'
-import { useLocaleReceiver } from 'antd/es/locale-provider/LocaleReceiver'
-import defaultLocale from 'antd/es/locale/default'
+import { useLocaleReceiver } from 'antd/lib/locale-provider/LocaleReceiver'
+import defaultLocale from 'antd/lib/locale/default'
 import {
   QuestionCircleOutlined,
   CloseCircleOutlined,
@@ -238,7 +238,9 @@ export const BaseItem: React.FC<React.PropsWithChildren<IFormItemProps>> = ({
           )}
           <label>{label}</label>
           {!asterisk && requiredMark === 'optional' && (
-            <span className={`${prefixCls}-optional`}>{formLocale?.optional || defaultLocale.Form?.optional}</span>
+            <span className={`${prefixCls}-optional`}>
+              {formLocale?.optional || defaultLocale.Form?.optional}
+            </span>
           )}
         </span>
       </div>


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

- Change the subpath that depends on antd in the FormItem component
- code format
