### PR TITLE
fix(antd/next): array-collapse onAdd function nullable issue

### DIFF
--- a/packages/antd/src/array-collapse/index.tsx
+++ b/packages/antd/src/array-collapse/index.tsx
@@ -210,7 +210,7 @@ export const ArrayCollapse: ComposedArrayCollapse = observer((props) => {
   return (
     <ArrayBase
       onAdd={(index) => {
-        onAdd(index)
+        onAdd?.(index)
         setActiveKeys(insertActiveKeys(activeKeys, index))
       }}
       onCopy={onCopy}

--- a/packages/next/src/array-collapse/index.tsx
+++ b/packages/next/src/array-collapse/index.tsx
@@ -209,7 +209,7 @@ export const ArrayCollapse: ComposedArrayCollapse = observer(
     return (
       <ArrayBase
         onAdd={(index) => {
-          onAdd(index)
+          onAdd?.(index)
           setExpandKeys(insertExpandedKeys(expandKeys, index))
         }}
         onCopy={onCopy}


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
不好意思没注意到onAdd的类型可能是undefined，但我很奇怪，为什么我的编辑器显示的类型是非空，但是看IArrayBaseProps的定义却都是optiional的