### PR TITLE
fix(core): onInput ignore HTMLInputEvent propagation

### DIFF
--- a/packages/core/src/__tests__/field.spec.ts
+++ b/packages/core/src/__tests__/field.spec.ts
@@ -2346,3 +2346,19 @@ test('field destructor path with display none', () => {
   expect(form.values).toEqual({})
   expect(aa.value).toEqual([])
 })
+
+test('onInput should ignore HTMLInputEvent propagation', async () => {
+  const form = attach(createForm<any>())
+  const mockHTMLInput = { value: '321' }
+  const mockDomEvent = { target: mockHTMLInput, currentTarget: mockHTMLInput }
+  const aa = attach(
+    form.createField({
+      name: 'aa',
+    })
+  )
+  await aa.onInput(mockDomEvent)
+  expect(aa.value).toEqual('321')
+
+  await aa.onInput({ target: { value: '2' }, currentTarget: { value: '4' } })
+  expect(aa.value).toEqual('321')
+})

--- a/packages/core/src/models/Field.ts
+++ b/packages/core/src/models/Field.ts
@@ -459,12 +459,19 @@ export class Field<
   getState: IModelGetter<IFieldState> = createStateGetter(this)
 
   onInput = async (...args: any[]) => {
+    const isHTMLInputEventFromSelf = (args: any[]) =>
+      isHTMLInputEvent(args[0])
+        ? args[0]?.target === args[0]?.currentTarget
+        : true
     const getValues = (args: any[]) => {
       if (args[0]?.target) {
         if (!isHTMLInputEvent(args[0])) return args
       }
       return getValuesFromEvent(args)
     }
+
+    if (!isHTMLInputEventFromSelf(args)) return
+
     const values = getValues(args)
     const value = values[0]
     this.caches.inputting = true


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

忽略 input HTML 元素事件冒泡行为，现状会错误地把 ObjectField value 变成字符串

- React：https://codesandbox.io/s/7x8qfg?file=/App.tsx
- Vue：https://codesandbox.io/s/pmlrmx?file=/src/App.vue

现象：输入框输入完后，form.values 从 `{ container: { input: '' } }` 变成了 `{ container: '' }`