### PR TITLE
test(core): array.spec.test 容错部分将注释替换为 expect, 并将注释中的错误进行修正

### DIFF
--- a/packages/core/src/__tests__/array.spec.ts
+++ b/packages/core/src/__tests__/array.spec.ts
@@ -284,23 +284,36 @@ test('fault tolerance', () => {
     })
   )
   array.setValue({} as any)
-  array.push(11) //[11]
-  array.pop() //[]
-  array.remove(1) //[]
-  array.shift() //[]
-  array.unshift(1) //[1]
-  array.move(0, 1) //[undefined,1]
-  array.moveUp(1) //[1,undefined]
-  array.moveDown(1) //[1,undefined]
-  array.insert(1) //[1,undefined]
+  array.push(11)
+  expect(array.value).toEqual([11])
+  array.pop()
+  expect(array.value).toEqual([])
+  array.remove(1)
+  expect(array.value).toEqual([])
+  array.shift()
+  expect(array.value).toEqual([])
+  array.unshift(1)
+  expect(array.value).toEqual([1])
+  array.move(0, 1)
+  expect(array.value).toEqual([1])
+  array.moveUp(1)
+  expect(array.value).toEqual([undefined, 1])
+  array.moveDown(1)
   expect(array.value).toEqual([1, undefined])
-  array2.move(1, 1) //[1,undefined]
-  array2.moveUp(2) //[1,undefined]
-  array2.moveUp(0) //[1,undefined]
-  array2.moveDown(0) //[undefined,1]
-  array2.moveDown(1) //[undefined,1]
-  array2.moveDown(2) //[undefined,1]
+  array.insert(1)
   expect(array.value).toEqual([1, undefined])
+  array2.move(1, 1)
+  expect(array2.value).toEqual([1, 2])
+  array2.moveUp(2)
+  expect(array2.value).toEqual([1, undefined, 2])
+  array2.moveUp(0)
+  expect(array2.value).toEqual([undefined, 2, 1])
+  array2.moveDown(0)
+  expect(array2.value).toEqual([2, undefined, 1])
+  array2.moveDown(1)
+  expect(array2.value).toEqual([2, 1, undefined])
+  array2.moveDown(2)
+  expect(array2.value).toEqual([undefined, 2, 1])
 })
 
 test('mutation fault tolerance', () => {


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

core/src/__tests__/array.spec.test 容错部分`test('fault tolerance', () => {}` 部分测试注释不正确， 调整如下
1. 注释改为 expect
2. 修正错误部分（依据为当前 formily_next 分支实际运行结果）

在尝试修复 https://github.com/alibaba/formily/pull/3855#issuecomment-1596682183 这个问题， 发现一些测试用例不全， 注释错误， 给于修正。