### PR TITLE
fix(core): onInput not ignore when currentTarget is undefined

### DIFF
--- a/packages/core/src/__tests__/field.spec.ts
+++ b/packages/core/src/__tests__/field.spec.ts
@@ -2361,4 +2361,8 @@ test('onInput should ignore HTMLInputEvent propagation', async () => {
 
   await aa.onInput({ target: { value: '2' }, currentTarget: { value: '4' } })
   expect(aa.value).toEqual('321')
+
+  // currentTarget is undefined, skip ignore
+  await aa.onInput({ target: { value: '123' } })
+  expect(aa.value).toEqual('123')
 })

--- a/packages/core/src/models/Field.ts
+++ b/packages/core/src/models/Field.ts
@@ -460,7 +460,7 @@ export class Field<
 
   onInput = async (...args: any[]) => {
     const isHTMLInputEventFromSelf = (args: any[]) =>
-      isHTMLInputEvent(args[0])
+      isHTMLInputEvent(args[0]) && 'currentTarget' in args[0]
         ? args[0]?.target === args[0]?.currentTarget
         : true
     const getValues = (args: any[]) => {


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

修复 React 事件流下 antd Radio 组件 onChange 时失效的问题。onChange 参数未有 currentTarget 时，均视为有效值。判断逻辑改成 target 与 currentTarget 都存在时，根据两者是否全等，决定其源事件抛出方式是否为冒泡