### PR TITLE
fix(react): fix field unmounted but can not update right model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
     if: contains(github.event.head_commit.message, 'chore(versions)') == false
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     if: contains(github.event.head_commit.message, 'chore(versions)') == false
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node_version }}
+      - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: 16
 
       - run: yarn -v
       - run: yarn --ignore-engines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,6 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     if: contains(github.event.head_commit.message, 'chore(versions)') == false
-    strategy:
-      matrix:
-        node_version: 16
-        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     if: contains(github.event.head_commit.message, 'chore(versions)') == false
     steps:
       - uses: actions/checkout@v1

--- a/packages/core/src/__tests__/form.spec.ts
+++ b/packages/core/src/__tests__/form.spec.ts
@@ -1713,3 +1713,11 @@ test('form initial values ref should not changed with setInitialValues', () => {
   })
   expect(form.initialValues === values).toBeTruthy()
 })
+
+test('form query undefined query should not throw error', () => {
+  const form = attach(createForm())
+
+  ;(form.fields as any)['a'] = undefined
+  expect(() => form.query('*').take()).not.toThrowError()
+  expect(Object.keys(form.fields)).toEqual([])
+})

--- a/packages/react/src/components/Field.tsx
+++ b/packages/react/src/components/Field.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useField, useForm } from '../hooks'
-import { useAttach } from '../hooks/useAttach'
 import { ReactiveField } from './ReactiveField'
 import { FieldContext } from '../shared'
 import { JSXComponent, IFieldProps } from '../types'
@@ -10,9 +9,13 @@ export const Field = <D extends JSXComponent, C extends JSXComponent>(
 ) => {
   const form = useForm()
   const parent = useField()
-  const field = useAttach(
-    form.createField({ basePath: parent?.address, ...props })
-  )
+  const field = form.createField({ basePath: parent?.address, ...props })
+  useEffect(() => {
+    field?.onMount()
+    return () => {
+      field?.onUnmount()
+    }
+  }, [field])
   return (
     <FieldContext.Provider value={field}>
       <ReactiveField field={field}>{props.children}</ReactiveField>


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

当初为了修复 https://github.com/alibaba/formily/pull/3284 这个问题的原因主要是 StrictMode 场景下，form 组件被卸载，导致很多响应器被销毁，所以优化了一下 useAttach 逻辑，但这里的副作用是 useAttach 内部存在异步逻辑，对于 field 内部的渲染场景，会触发时序问题，还是得用最原始的 useEffect 实现才行

Fixed #3941 