### PR TITLE
fix(core): initial value should clear in destroy

### DIFF
--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -176,11 +176,18 @@ export const destroy = (
 ) => {
   const field = target[address]
   field?.dispose()
-  if (isDataField(field) && forceClear) {
+  if (isDataField(field)) {
     const form = field.form
     const path = field.path
-    form.deleteValuesIn(path)
-    form.deleteInitialValuesIn(path)
+    if (forceClear) {
+      form.deleteValuesIn(path)
+    }
+
+    // 在 schema 上有定义 initialValue (JSX prop name: default)
+    const shouldClearInitial = forceClear || !isUndef(field.props.initialValue)
+    if (shouldClearInitial) {
+      form.deleteInitialValuesIn(path)
+    }
   }
   delete target[address]
 }


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**


---

## What have you changed?

变更 destory 中 initialValues 处理逻辑

before: 子组件销毁调用的 `patchFieldStates()` 处理中, `destory` 默认不清理 `form.initialValues`, 在嵌套数组的情况下, 会出现一下问题 #4024 
after: 在 destory 中判断, 如果 field 的 schema 存在不为 undefined 的 `initialValue` 属性(即 `default`), 在销毁的时候进行删除, 以还原 `form.initialValues` 

讨论:
> 那么问题来了，是否应该在组件销毁的时候重置 schema 上所声明的 initialValue呢？ 在我的部分使用场景中，其实有跟 https://github.com/alibaba/formily/issues/4024 楼主类似的疑惑， 我使用 form 上的 initialValues 是期望 reset 的时候能重置回去整个表单的数据； 如果 schema 上配置的 default 即 initialValue 对表单的 initialValues 产生了影响，还是是非常费解的。 所以我给出一下总结和建议

1. 使用原始方案，对form.initialValues 进行更新
2. 按照我的方案，如果有删除，那么对有 schema 上进行 initalValue（default）标注的 path 所对应的 form.initialValues 中的字段进行删除
3. 添加一个类似 IFormMergeStrategy 的属性来让用户决定如何判断
4. 新增一个 freezeInitialValue 初始值，这将是一个不会变的 form 初始值，以方便用户在重置的时候直接 reset 到这个最初的，不会被改变的初始值
