### PR TITLE
feat: support reuse existed properties when schema addProperty

### DIFF
--- a/packages/json-schema/src/schema.ts
+++ b/packages/json-schema/src/schema.ts
@@ -222,6 +222,7 @@ export class Schema<
     >
   ) => {
     this.properties = this.properties || {}
+    if (this.properties[key]) return this.properties[key]
     this.properties[key] = new Schema(schema, this)
     this.properties[key].name = key
     return this.properties[key]
@@ -266,6 +267,7 @@ export class Schema<
   ) => {
     if (!schema) return
     this.patternProperties = this.patternProperties || {}
+    if (this.patternProperties[key]) return this.patternProperties[key]
     this.patternProperties[key] = new Schema(schema, this)
     this.patternProperties[key].name = key
     return this.patternProperties[key]


### PR DESCRIPTION
#### schema addProperty时支持复用已存在的property
##### before
``` javascript
<SchemaField.Object name="obj" title="first obj">
  <SchemaField.String
    name="property1"
    title="this is property1"
    x-decorator="FormItem"
    x-component="Input"
   />
</SchemaField.Object>
<SchemaField.Object name="obj" title="second obj">
  <SchemaField.String
    name="property2"
    title="this is property2"
    x-decorator="FormItem"
    x-component="Input"
   />
</SchemaField.Object>
```
output:
```
// only property2 rendered, because Formily will always new Schema when addProperty('obj', schema), so the existed property1 will be replaced
title: second obj
  this is property2：value of property2
```

##### after
```
// property1 and property2 will be merged, the schema of first "obj" schema will be retained
title: first obj
  this is property1：value of property1
  this is property2：value of property2
```

实践里如果开发者希望能抽象出一些更内聚的业务 Field，支持分离的 object 自动合并可能会更灵活一些，原来替换的表现可能会造成一些困惑。

``` javascript
import Field1 from './Field1'
import Field2 from './Field2'

/** 
* Field1.js
* <SchemaField.Object name="hugeObject">
*   <SchemaField.Object name="hugeObject.yyy">something</SchemaField.Object>
* </SchemaField.Object>
*/
/** 
* Field2.js
* <SchemaField.Object name="hugeObject">
*   <SchemaField.Object name="hugeObject.zzz">something</SchemaField.Object>
* </SchemaField.Object>
*/

const MyField = () => {
  return (
    <Form>
      <SchemaField.Object name="hugeObject">
        <SchemaField.String name="hugeObject.xxx" />
      </SchemaField.Object>
      <Field1 />
      <Field2 />
    </Form>
  )
}
```

