### PR TITLE
fix: baseReaction 初始化执行两次的问题

### DIFF
--- a/packages/json-schema/src/compiler.ts
+++ b/packages/json-schema/src/compiler.ts
@@ -124,9 +124,11 @@ export const patchSchemaCompile = (
     })
     if (compiled === undefined) return
     if (demand) {
-      if (collected || !targetState.initialized) {
-        patchStateFormSchema(targetState, path, compiled)
-      }
+      untracked(() => {
+        if (collected || !targetState.initialized) {
+          patchStateFormSchema(targetState, path, compiled)
+        }
+      })
     } else {
       patchStateFormSchema(targetState, path, compiled)
     }


### PR DESCRIPTION
patchSchemaCompile 收集了 field.initialized
field在初始化结束后会标记  field.initialized = true
所以 base reacttion 全部都会执行两次

修复：field.initialized 丢在 untracked 中，不在进行收集

_Before_ submitting a pull request, please make sure the following is done...

- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [ ] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
