### PR TITLE
fix(element): wrong RadioGroup optionType value

### DIFF
--- a/packages/element/src/radio/index.ts
+++ b/packages/element/src/radio/index.ts
@@ -26,7 +26,7 @@ export type RadioGroupProps = ElRadioGroupProps & {
       })
     | string
   )[]
-  optionType: 'defalt' | 'button'
+  optionType: 'default' | 'button'
 }
 
 export type RadioProps = ElRadioProps


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
对于 `RadioGroupProps` 的 `optionType` 属性值 ，组件文档、代码中都使用了 `default` ，但是 `type RadioGroupProps` 没有正确的标识 `optionType`
