### PR TITLE
fix: when validating a specific field, if there are other fields in a failed validation state, an exception will also be thrown. 

### DIFF
--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -903,7 +903,9 @@ export const batchValidate = async (
       LifeCycleTypes.ON_FORM_VALIDATE_FAILED,
       LifeCycleTypes.ON_FIELD_VALIDATE_FAILED
     )
-    throw target.errors
+    if (target.errors.some((item) => FormPath.parse(pattern).match(item.path))) {
+      throw target.errors
+    }
   }
   notify(
     target,


### PR DESCRIPTION
## What have you changed?
when validating a specific field, if there are other fields in a failed validation state, an exception will also be thrown. 

For related issues feedback, please refer to https://github.com/alibaba/formily/issues/3825.