### PR TITLE
feat: add x-validator-merge prop && registerMergeRules api

### DIFF
--- a/packages/core/src/models/Field.ts
+++ b/packages/core/src/models/Field.ts
@@ -6,6 +6,7 @@ import {
   isArr,
 } from '@formily/shared'
 import {
+  Validator,
   ValidatorTriggerType,
   parseValidatorDescriptions,
 } from '@formily/validator'
@@ -78,6 +79,7 @@ export class Field<
   feedbacks: IFieldFeedback[]
   caches: IFieldCaches = {}
   requests: IFieldRequests = {}
+  validatorMerge: Record<string, Validator>
   constructor(
     address: FormPathPattern,
     props: IFieldProps<Decorator, Component, TextType, ValueType>,

--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -310,6 +310,7 @@ export const validateToFeedbacks = async (
     triggerType,
     validateFirst: field.props.validateFirst ?? field.form.props.validateFirst,
     context: { field, form: field.form },
+    validatorMerge: field.validatorMerge,
   })
 
   batch(() => {

--- a/packages/json-schema/src/compiler.ts
+++ b/packages/json-schema/src/compiler.ts
@@ -110,7 +110,9 @@ export const patchCompile = (
 }
 
 export const patchSchemaCompile = (
-  targetState: IGeneralFieldState,
+  targetState: IGeneralFieldState & {
+    schema: ISchema
+  },
   sourceSchema: ISchema,
   scope: any,
   demand = false
@@ -131,4 +133,5 @@ export const patchSchemaCompile = (
       patchStateFormSchema(targetState, path, compiled)
     }
   })
+  targetState['schema'] = sourceSchema
 }

--- a/packages/json-schema/src/schema.ts
+++ b/packages/json-schema/src/schema.ts
@@ -151,6 +151,8 @@ export class Schema<
   ['x-display']?: Display;
   //校验器
   ['x-validator']?: Validator;
+  //覆盖校验器，可以合并 全局校验 和 简写校验
+  ['x-validator-merge']?: Record<string, Validator>;
   //装饰器
   ['x-decorator']?: Decorator;
   //装饰器属性

--- a/packages/json-schema/src/shared.ts
+++ b/packages/json-schema/src/shared.ts
@@ -2,6 +2,7 @@ import { isFn, each, isPlainObj, isArr, toArr, FormPath } from '@formily/shared'
 import { isObservable, untracked } from '@formily/reactive'
 import { Schema } from './schema'
 import { ISchema } from './types'
+import { registerMergeRules } from '@formily/validator'
 
 const REVA_ACTIONS_KEY = Symbol.for('__REVA_ACTIONS')
 
@@ -36,6 +37,7 @@ export const SchemaStateMap = {
   'x-display': 'display',
   'x-pattern': 'pattern',
   'x-validator': 'validator',
+  'x-validator-merge': 'validatorMerge',
   'x-decorator': 'decoratorType',
   'x-component': 'componentType',
   'x-decorator-props': 'decoratorProps',
@@ -100,6 +102,9 @@ export const traverseSchema = (
   schema: ISchema,
   visitor: (value: any, path: any[], omitCompile?: boolean) => void
 ) => {
+  if (schema['x-validator-merge'] !== undefined) {
+    registerMergeRules(schema['x-validator-merge'])
+  }
   if (schema['x-validator'] !== undefined) {
     visitor(
       schema['x-validator'],

--- a/packages/validator/src/__tests__/validator.spec.ts
+++ b/packages/validator/src/__tests__/validator.spec.ts
@@ -4,12 +4,22 @@ import {
   registerValidateFormats,
   setValidateLanguage,
   registerValidateMessageTemplateEngine,
+  registerMergeRules,
 } from '../index'
 
 registerValidateRules({
   custom: (value) => (value === '123' ? 'custom error' : ''),
   customBool: () => false,
   customBool2: () => true,
+  customBool3: (value) => {
+    return value === 'registerValidateRules'
+  },
+})
+
+registerMergeRules({
+  customBool3: (value) => {
+    return value === 'registerMergeRules'
+  },
 })
 
 registerValidateFormats({
@@ -529,5 +539,41 @@ test('validator order with format', async () => {
       },
     ]),
     'The field value is required'
+  )
+})
+
+test('validator merge', async () => {
+  registerMergeRules({
+    customBool3: (value) => {
+      return value === 'registerMergeRules'
+    },
+  })
+  noError(
+    await validate('registerMergeRules', {
+      customBool3: true,
+      message: 'custom error',
+    })
+  )
+})
+
+/**
+ * @description other test case should be before this one, because it will change the default rules
+ */
+test('validator merge required', async () => {
+  registerMergeRules({})
+  hasError(
+    await validate('', [{ required: true }]),
+    'The field value is required'
+  )
+
+  registerMergeRules({
+    required: () => {
+      return true
+    },
+  })
+  noError(
+    await validate('', {
+      required: true,
+    })
   )
 })

--- a/packages/validator/src/registry.ts
+++ b/packages/validator/src/registry.ts
@@ -38,7 +38,14 @@ const registry = {
     language: getBrowserlanguage(),
   },
   formats: {},
-  rules: {},
+  rules: {
+    // 全局校验规则
+    global: {},
+    // 简写校验规则
+    easy: {},
+    // 自定义校验规则
+    merge: {},
+  },
   template: null,
 }
 
@@ -88,21 +95,60 @@ export const getValidateMessageTemplateEngine = () => registry.template
 export const getValidateFormats = (key?: string) =>
   key ? registry.formats[key] : registry.formats
 
+/**
+ * @description 覆盖规则
+ * 全局规则 < 简写规则 < 用户自定义规则
+ * @param key
+ * @returns
+ */
 export const getValidateRules = <T>(
   key?: T
 ): T extends string
   ? ValidatorFunction
-  : { [key: string]: ValidatorFunction } =>
-  key ? registry.rules[key as any] : registry.rules
+  : { [key: string]: ValidatorFunction } => {
+  let rules = {
+    ...registry.rules['global'],
+    ...registry.rules['easy'],
+    ...registry.rules['merge'],
+  }
+  return key ? rules[key as any] : rules
+}
 
 export const registerValidateLocale = (locale: IRegistryLocales) => {
   registry.locales.messages = deepmerge(registry.locales.messages, locale)
 }
 
+/**
+ * @description 全局规则
+ * @param rules
+ */
 export const registerValidateRules = (rules: IRegistryRules) => {
   each(rules, (rule, key) => {
     if (isFn(rule)) {
-      registry.rules[key] = rule
+      registry.rules['global'][key] = rule
+    }
+  })
+}
+/**
+ * @description 简写规则
+ * @param rules
+ */
+export const registerEasyRules = (rules: IRegistryRules) => {
+  each(rules, (rule, key) => {
+    if (isFn(rule)) {
+      registry.rules['easy'][key] = rule
+    }
+  })
+}
+
+/**
+ * @description 自定义规则
+ * @param rules
+ */
+export const registerMergeRules = (rules: IRegistryRules) => {
+  each(rules, (rule, key) => {
+    if (isFn(rule)) {
+      registry.rules['merge'][key] = rule
     }
   })
 }

--- a/packages/validator/src/types.ts
+++ b/packages/validator/src/types.ts
@@ -111,4 +111,5 @@ export interface IValidatorOptions<Context = any> {
   validateFirst?: boolean
   triggerType?: ValidatorTriggerType
   context?: Context
+  validatorMerge?: Record<string, Validator>
 }


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

fix https://github.com/alibaba/formily/issues/4204

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?


# description

This PR addresses the following issues and provides the following features:

- 1 Added the `x-validator-merge` attribute to tags for merging with global validation. Custom global validation is sometimes needed, but due to Formity’s previous design, global validation, like `required`, couldn’t have custom messages. Even if attributes are set in `x-validator`, they are added as additional rules rather than replacing the existing ones. The `x-validator-merge` attribute allows merging global and local validations.

- 2 Introduced the `registerMergeRules` API, which works similarly to `registerValidateRules`, allowing functions to override default global validation rules in Formity.

- 3 Distinguished the state of rules into four types, with the first three being mergeable and the last one overriding the previous ones (refer to `packages/validator/src/registry.ts`):
  - 3.1 Global validation
  - 3.2 Shorthand property validation: `required`, `maximum`, `minimum`
  - 3.3 Local validation (mergeable): Rules specified by `x-validator-merge` or `registerMergeRules`
  - 3.4 Validator: Rules specified by `x-validator`, which do not participate in merging operations, as determined by Ant Design's properties

- 4 Add the `schema` variable to the third function in the validation function. This helps in accessing schema information within custom validation functions. Previously, the `context` parameter was transformed by the `SchemaStateMap` variable in `packages/json-schema/src/shared.ts`, making it impossible for developers to retrieve information such as `required`, `maximum`, or `minimum`

## registerMergeRules(api)

example

```tsx
import React from 'react'
import { createForm, } from '@formily/core'
import {registerMergeRules} from "@formily/validator"
import { createSchemaField } from '@formily/react'
import { Form, FormItem, Input, NumberPicker } from '@formily/antd'

const form = createForm()

const SchemaField = createSchemaField({
  components: {
    Input,
    FormItem,
    NumberPicker,
  },
})
registerMergeRules({
  required:(e,ctx)=>{
    console.log(e, ctx)
    if(!e){
      return "jjjjjjjjjjjjjjj"
    }
  }
})
export default () => (
  <Form form={form} labelCol={6} wrapperCol={10}>
    <SchemaField>
      <SchemaField.String
        maximum={5}
        title={"d"}
        name="8"
        required
        x-component="Input"
        x-decorator="FormItem"
      />
    
    </SchemaField>
  </Form>
)
```

## x-validator-merge(prop)

example

```tsx
import React from 'react'
import { createForm, registerValidateRules,registerMergeRules } from '@formily/core'
import { createSchemaField } from '@formily/react'
import { Form, FormItem, Input, NumberPicker } from '@formily/antd'

const form = createForm()

const SchemaField = createSchemaField({
  components: {
    Input,
    FormItem,
    NumberPicker,
  },
})

export default () => (
  <Form form={form} labelCol={6} wrapperCol={10}>
    <SchemaField>
      <SchemaField.String
        maximum={5}
        name="8"
        required
         x-validator-merge={{
          required(value) {
              if (!value) return 'customer merge'
          }
         }}
        x-component="Input"
        x-decorator="FormItem"
      />
    
    </SchemaField>
  </Form>
)
```







