### PR TITLE
feat: (core) x-compile-omitted  supports object path-like keys

### DIFF
--- a/packages/json-schema/src/__tests__/compiler.spec.ts
+++ b/packages/json-schema/src/__tests__/compiler.spec.ts
@@ -271,11 +271,17 @@ test('patchSchemaCompile x-compile-omitted', () => {
   const targetState = {
     title: '',
     validator: [],
+    componentProps: {
+      aa: 0,
+    },
   }
   patchSchemaCompile(
     targetState as any,
     {
       title: '132',
+      'x-component-props': {
+        aa: '{{field.value}}',
+      },
       'x-validator': [
         {
           remoteCheckUniq: '{{field.value}}',
@@ -292,17 +298,28 @@ test('patchSchemaCompile x-compile-omitted', () => {
   expect(targetState).toEqual({
     title: '132',
     validator: [{ remoteCheckUniq: 888 }],
+    componentProps: {
+      aa: 888,
+    },
   })
 
   const targetOmitState = {
     title: '',
     validator: [],
+    componentProps: {
+      aa: 0,
+      bb: 0,
+    },
   }
   patchSchemaCompile(
     targetOmitState as any,
     {
       title: '132',
-      'x-compile-omitted': ['x-validator'],
+      'x-compile-omitted': ['x-validator', 'x-component-props.aa'],
+      'x-component-props': {
+        aa: '{{field.value}}',
+        bb: '{{field.value}}',
+      },
       'x-validator': [
         {
           remoteCheckUniq: '{{field.value}}',
@@ -318,6 +335,10 @@ test('patchSchemaCompile x-compile-omitted', () => {
   )
   expect(targetOmitState).toEqual({
     title: '132',
+    componentProps: {
+      aa: '{{field.value}}',
+      bb: 888,
+    },
     validator: [{ remoteCheckUniq: '{{field.value}}' }],
   })
 })

--- a/packages/json-schema/src/shared.ts
+++ b/packages/json-schema/src/shared.ts
@@ -119,7 +119,10 @@ export const traverseSchema = (
       return
     if (String(path[0]).indexOf('x-') == -1 && isFn(target)) return
     if (SchemaNestedMap[path[0]]) return
-    if (schema['x-compile-omitted']?.indexOf(path[0]) > -1) {
+    if (
+      schema['x-compile-omitted']?.indexOf(path[0]) > -1 ||
+      schema['x-compile-omitted']?.indexOf(path.join('.')) > -1
+    ) {
       visitor(target, path, true)
       return
     }


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

The x-compile-omitted feature now supports object path-like keys (e.g., a.b) instead of being limited to single-level keys.

before: 
```js
{
 'x-compile-omitted': ['x-validator']
}
```

after:
```js
{
 'x-compile-omitted': ['x-validator', 'x-component-props.aa']
}
```

