### PR TITLE
fix(antd): fix antd/next render error at React 19

### DIFF
--- a/packages/antd/src/__builtins__/portal.tsx
+++ b/packages/antd/src/__builtins__/portal.tsx
@@ -11,8 +11,9 @@ const PortalMap = observable(new Map<string | symbol, React.ReactNode>())
 
 export const createPortalProvider = (id: string | symbol) => {
   const Portal = (props: React.PropsWithChildren<IPortalProps>) => {
-    if (props.id && !PortalMap.has(props.id)) {
-      PortalMap.set(props.id, null)
+    const portalId = props.id || id
+    if (portalId && !PortalMap.has(portalId)) {
+      PortalMap.set(portalId, null)
     }
 
     return (
@@ -20,17 +21,14 @@ export const createPortalProvider = (id: string | symbol) => {
         {props.children}
         <Observer>
           {() => {
-            if (!props.id) return null
-            const portal = PortalMap.get(props.id)
+            if (!portalId) return null
+            const portal = PortalMap.get(portalId)
             if (portal) return createPortal(portal, document.body)
             return null
           }}
         </Observer>
       </Fragment>
     )
-  }
-  Portal.defaultProps = {
-    id,
   }
   return Portal
 }

--- a/packages/antd/src/__builtins__/portal.tsx
+++ b/packages/antd/src/__builtins__/portal.tsx
@@ -11,7 +11,7 @@ const PortalMap = observable(new Map<string | symbol, React.ReactNode>())
 
 export const createPortalProvider = (id: string | symbol) => {
   const Portal = (props: React.PropsWithChildren<IPortalProps>) => {
-    const portalId = props.id || id
+    const portalId = props.id ?? id
     if (portalId && !PortalMap.has(portalId)) {
       PortalMap.set(portalId, null)
     }

--- a/packages/antd/src/array-collapse/index.tsx
+++ b/packages/antd/src/array-collapse/index.tsx
@@ -78,152 +78,157 @@ const insertActiveKeys = (activeKeys: number[], index: number) => {
   }, [])
 }
 
-export const ArrayCollapse: ComposedArrayCollapse = observer((props) => {
-  const field = useField<ArrayField>()
-  const dataSource = Array.isArray(field.value) ? field.value : []
-  const [activeKeys, setActiveKeys] = useState<number[]>(
-    takeDefaultActiveKeys(dataSource.length, props.defaultOpenPanelCount)
-  )
-  const schema = useFieldSchema()
-  const prefixCls = usePrefixCls('formily-array-collapse', props)
-  useEffect(() => {
-    if (!field.modified && dataSource.length) {
-      setActiveKeys(
-        takeDefaultActiveKeys(dataSource.length, props.defaultOpenPanelCount)
+export const ArrayCollapse: ComposedArrayCollapse = observer(
+  ({ defaultOpenPanelCount = 5, ...props }) => {
+    const field = useField<ArrayField>()
+    const dataSource = Array.isArray(field.value) ? field.value : []
+    const [activeKeys, setActiveKeys] = useState<number[]>(
+      takeDefaultActiveKeys(dataSource.length, defaultOpenPanelCount)
+    )
+    const schema = useFieldSchema()
+    const prefixCls = usePrefixCls('formily-array-collapse', props)
+    useEffect(() => {
+      if (!field.modified && dataSource.length) {
+        setActiveKeys(
+          takeDefaultActiveKeys(dataSource.length, defaultOpenPanelCount)
+        )
+      }
+    }, [dataSource.length, field])
+    if (!schema) throw new Error('can not found schema object')
+    const { onAdd, onCopy, onRemove, onMoveDown, onMoveUp } = props
+
+    const renderAddition = () => {
+      return schema.reduceProperties((addition, schema, key) => {
+        if (isAdditionComponent(schema)) {
+          return <RecursionField schema={schema} name={key} />
+        }
+        return addition
+      }, null)
+    }
+    const renderEmpty = () => {
+      if (dataSource.length) return
+      return (
+        <Card className={cls(`${prefixCls}-item`, props.className)}>
+          <Empty />
+        </Card>
       )
     }
-  }, [dataSource.length, field])
-  if (!schema) throw new Error('can not found schema object')
-  const { onAdd, onCopy, onRemove, onMoveDown, onMoveUp } = props
 
-  const renderAddition = () => {
-    return schema.reduceProperties((addition, schema, key) => {
-      if (isAdditionComponent(schema)) {
-        return <RecursionField schema={schema} name={key} />
-      }
-      return addition
-    }, null)
-  }
-  const renderEmpty = () => {
-    if (dataSource.length) return
-    return (
-      <Card className={cls(`${prefixCls}-item`, props.className)}>
-        <Empty />
-      </Card>
-    )
-  }
+    const renderItems = () => {
+      return (
+        <Collapse
+          {...props}
+          activeKey={activeKeys}
+          onChange={(keys: string[]) => setActiveKeys(toArr(keys).map(Number))}
+          className={cls(`${prefixCls}-item`, props.className)}
+        >
+          {dataSource.map((item, index) => {
+            const items = Array.isArray(schema.items)
+              ? schema.items[index] || schema.items[0]
+              : schema.items
 
-  const renderItems = () => {
-    return (
-      <Collapse
-        {...props}
-        activeKey={activeKeys}
-        onChange={(keys: string[]) => setActiveKeys(toArr(keys).map(Number))}
-        className={cls(`${prefixCls}-item`, props.className)}
-      >
-        {dataSource.map((item, index) => {
-          const items = Array.isArray(schema.items)
-            ? schema.items[index] || schema.items[0]
-            : schema.items
+            const panelProps = field
+              .query(`${field.address}.${index}`)
+              .get('componentProps')
+            const props: CollapsePanelProps = items['x-component-props']
+            const header = () => {
+              const header = panelProps?.header || props.header || field.title
+              const path = field.address.concat(index)
+              const errors = field.form.queryFeedbacks({
+                type: 'error',
+                address: `${path}.**`,
+              })
+              return (
+                <ArrayBase.Item
+                  index={index}
+                  record={() => field.value?.[index]}
+                >
+                  <RecursionField
+                    schema={items}
+                    name={index}
+                    filterProperties={(schema) => {
+                      if (!isIndexComponent(schema)) return false
+                      return true
+                    }}
+                    onlyRenderProperties
+                  />
+                  {errors.length ? (
+                    <Badge
+                      size="small"
+                      className="errors-badge"
+                      count={errors.length}
+                    >
+                      {header}
+                    </Badge>
+                  ) : (
+                    header
+                  )}
+                </ArrayBase.Item>
+              )
+            }
 
-          const panelProps = field
-            .query(`${field.address}.${index}`)
-            .get('componentProps')
-          const props: CollapsePanelProps = items['x-component-props']
-          const header = () => {
-            const header = panelProps?.header || props.header || field.title
-            const path = field.address.concat(index)
-            const errors = field.form.queryFeedbacks({
-              type: 'error',
-              address: `${path}.**`,
-            })
-            return (
-              <ArrayBase.Item index={index} record={() => field.value?.[index]}>
+            const extra = (
+              <ArrayBase.Item index={index} record={item}>
                 <RecursionField
                   schema={items}
                   name={index}
                   filterProperties={(schema) => {
-                    if (!isIndexComponent(schema)) return false
+                    if (!isOperationComponent(schema)) return false
                     return true
                   }}
                   onlyRenderProperties
                 />
-                {errors.length ? (
-                  <Badge
-                    size="small"
-                    className="errors-badge"
-                    count={errors.length}
-                  >
-                    {header}
-                  </Badge>
-                ) : (
-                  header
-                )}
+                {panelProps?.extra}
               </ArrayBase.Item>
             )
-          }
 
-          const extra = (
-            <ArrayBase.Item index={index} record={item}>
+            const content = (
               <RecursionField
                 schema={items}
                 name={index}
                 filterProperties={(schema) => {
-                  if (!isOperationComponent(schema)) return false
+                  if (isIndexComponent(schema)) return false
+                  if (isOperationComponent(schema)) return false
                   return true
                 }}
-                onlyRenderProperties
               />
-              {panelProps?.extra}
-            </ArrayBase.Item>
-          )
-
-          const content = (
-            <RecursionField
-              schema={items}
-              name={index}
-              filterProperties={(schema) => {
-                if (isIndexComponent(schema)) return false
-                if (isOperationComponent(schema)) return false
-                return true
-              }}
-            />
-          )
-          return (
-            <Collapse.Panel
-              {...props}
-              {...panelProps}
-              forceRender
-              key={index}
-              header={header()}
-              extra={extra}
-            >
-              <ArrayBase.Item index={index} key={index} record={item}>
-                {content}
-              </ArrayBase.Item>
-            </Collapse.Panel>
-          )
-        })}
-      </Collapse>
+            )
+            return (
+              <Collapse.Panel
+                {...props}
+                {...panelProps}
+                forceRender
+                key={index}
+                header={header()}
+                extra={extra}
+              >
+                <ArrayBase.Item index={index} key={index} record={item}>
+                  {content}
+                </ArrayBase.Item>
+              </Collapse.Panel>
+            )
+          })}
+        </Collapse>
+      )
+    }
+    return (
+      <ArrayBase
+        onAdd={(index) => {
+          onAdd?.(index)
+          setActiveKeys(insertActiveKeys(activeKeys, index))
+        }}
+        onCopy={onCopy}
+        onRemove={onRemove}
+        onMoveUp={onMoveUp}
+        onMoveDown={onMoveDown}
+      >
+        {renderEmpty()}
+        {renderItems()}
+        {renderAddition()}
+      </ArrayBase>
     )
   }
-  return (
-    <ArrayBase
-      onAdd={(index) => {
-        onAdd?.(index)
-        setActiveKeys(insertActiveKeys(activeKeys, index))
-      }}
-      onCopy={onCopy}
-      onRemove={onRemove}
-      onMoveUp={onMoveUp}
-      onMoveDown={onMoveDown}
-    >
-      {renderEmpty()}
-      {renderItems()}
-      {renderAddition()}
-    </ArrayBase>
-  )
-})
+)
 
 const CollapsePanel: React.FC<React.PropsWithChildren<CollapsePanelProps>> = ({
   children,
@@ -233,9 +238,6 @@ const CollapsePanel: React.FC<React.PropsWithChildren<CollapsePanelProps>> = ({
 
 CollapsePanel.displayName = 'CollapsePanel'
 
-ArrayCollapse.defaultProps = {
-  defaultOpenPanelCount: 5,
-}
 ArrayCollapse.displayName = 'ArrayCollapse'
 ArrayCollapse.CollapsePanel = CollapsePanel
 

--- a/packages/antd/src/form-button-group/index.tsx
+++ b/packages/antd/src/form-button-group/index.tsx
@@ -57,7 +57,7 @@ function getDefaultBackground() {
 }
 
 export const FormButtonGroup: ComposedButtonGroup = ({
-  align,
+  align = 'left',
   gutter,
   ...props
 }) => {
@@ -83,10 +83,6 @@ export const FormButtonGroup: ComposedButtonGroup = ({
   )
 }
 
-FormButtonGroup.defaultProps = {
-  align: 'left',
-}
-
 FormButtonGroup.FormItem = ({ gutter, ...props }) => {
   return (
     <BaseItem
@@ -109,7 +105,7 @@ FormButtonGroup.FormItem = ({ gutter, ...props }) => {
   )
 }
 
-FormButtonGroup.Sticky = ({ align, ...props }) => {
+FormButtonGroup.Sticky = ({ align = 'left', ...props }) => {
   const ref = useRef()
   const [color, setColor] = useState('transparent')
   const prefixCls = usePrefixCls('formily-button-group')
@@ -149,10 +145,6 @@ FormButtonGroup.Sticky = ({ align, ...props }) => {
       </div>
     </StickyBox>
   )
-}
-
-FormButtonGroup.Sticky.defaultProps = {
-  align: 'left',
 }
 
 export default FormButtonGroup

--- a/packages/antd/src/form-grid/index.tsx
+++ b/packages/antd/src/form-grid/index.tsx
@@ -101,17 +101,13 @@ export const FormGrid: ComposedFormGrid = observer(
 ) as any
 
 export const GridColumn: React.FC<React.PropsWithChildren<IGridColumnProps>> =
-  observer(({ gridSpan, children, ...props }) => {
+  observer(({ gridSpan = 1, children, ...props }) => {
     return (
       <div {...props} style={props.style} data-grid-span={gridSpan}>
         {children}
       </div>
     )
   })
-
-GridColumn.defaultProps = {
-  gridSpan: 1,
-}
 
 FormGrid.createFormGrid = createFormGrid
 FormGrid.useGridSpan = useGridSpan

--- a/packages/antd/src/form-layout/index.tsx
+++ b/packages/antd/src/form-layout/index.tsx
@@ -66,7 +66,14 @@ export const FormLayout: React.FC<React.PropsWithChildren<IFormLayoutProps>> & {
   useFormLayout: () => IFormLayoutContext
   useFormDeepLayout: () => IFormLayoutContext
   useFormShallowLayout: () => IFormLayoutContext
-} = ({ shallow, children, prefixCls, className, style, ...otherProps }) => {
+} = ({
+  shallow = true,
+  children,
+  prefixCls,
+  className,
+  style,
+  ...otherProps
+}) => {
   const { ref, props } = useResponsiveFormLayout(otherProps)
   const deepLayout = useFormDeepLayout()
   const formPrefixCls = usePrefixCls('form', { prefixCls })
@@ -107,10 +114,6 @@ export const FormLayout: React.FC<React.PropsWithChildren<IFormLayoutProps>> & {
       {renderChildren()}
     </div>
   )
-}
-
-FormLayout.defaultProps = {
-  shallow: true,
 }
 
 FormLayout.useFormDeepLayout = useFormDeepLayout

--- a/packages/antd/src/form/index.tsx
+++ b/packages/antd/src/form/index.tsx
@@ -13,7 +13,7 @@ export interface FormProps extends IFormLayoutProps {
 
 export const Form: React.FC<React.PropsWithChildren<FormProps>> = ({
   form,
-  component,
+  component = 'form',
   onAutoSubmit,
   onAutoSubmitFailed,
   previewTextPlaceholder,
@@ -41,10 +41,6 @@ export const Form: React.FC<React.PropsWithChildren<FormProps>> = ({
     return <FormProvider form={form}>{renderContent(form)}</FormProvider>
   if (!top) throw new Error('must pass form instance by createForm')
   return renderContent(top)
-}
-
-Form.defaultProps = {
-  component: 'form',
 }
 
 export default Form

--- a/packages/antd/src/select-table/index.tsx
+++ b/packages/antd/src/select-table/index.tsx
@@ -142,11 +142,11 @@ const addPrimaryKey = (dataSource, rowKey, primaryKey) =>
 
 export const SelectTable: ComposedSelectTable = observer((props) => {
   const {
-    mode,
+    mode = 'multiple',
     dataSource: propsDataSource,
     optionAsValue,
-    valueType,
-    showSearch,
+    valueType = 'all',
+    showSearch = false,
     filterOption,
     filterSort,
     onSearch,
@@ -155,7 +155,7 @@ export const SelectTable: ComposedSelectTable = observer((props) => {
     value,
     onChange,
     rowSelection,
-    primaryKey: rowKey,
+    primaryKey: rowKey = 'key',
     ...otherTableProps
   } = props
   const prefixCls = usePrefixCls('formily-select-table', props)
@@ -408,12 +408,5 @@ const TableColumn: React.FC<
 > = () => <></>
 
 SelectTable.Column = TableColumn
-
-SelectTable.defaultProps = {
-  showSearch: false,
-  valueType: 'all',
-  primaryKey: 'key',
-  mode: 'multiple',
-}
 
 export default SelectTable

--- a/packages/antd/src/transfer/index.tsx
+++ b/packages/antd/src/transfer/index.tsx
@@ -2,6 +2,8 @@ import { connect, mapProps } from '@formily/react'
 import { Transfer as AntdTransfer } from 'antd'
 import { isVoidField } from '@formily/core'
 
+const renderTitle = (item: any) => item.title
+
 export const Transfer = connect(
   AntdTransfer,
   mapProps(
@@ -12,6 +14,7 @@ export const Transfer = connect(
       if (isVoidField(field)) return props
       return {
         ...props,
+        render: props.render || renderTitle,
         dataSource:
           field.dataSource?.map((item) => {
             return {
@@ -24,9 +27,5 @@ export const Transfer = connect(
     }
   )
 )
-
-Transfer.defaultProps = {
-  render: (item) => item.title,
-}
 
 export default Transfer

--- a/packages/next/src/__builtins__/portal.tsx
+++ b/packages/next/src/__builtins__/portal.tsx
@@ -11,8 +11,9 @@ const PortalMap = observable(new Map<string | symbol, React.ReactNode>())
 
 export const createPortalProvider = (id: string | symbol) => {
   const Portal = (props: React.PropsWithChildren<IPortalProps>) => {
-    if (props.id && !PortalMap.has(props.id)) {
-      PortalMap.set(props.id, null)
+    const protalId = id
+    if (protalId && !PortalMap.has(protalId)) {
+      PortalMap.set(protalId, null)
     }
 
     return (
@@ -20,17 +21,14 @@ export const createPortalProvider = (id: string | symbol) => {
         {props.children}
         <Observer>
           {() => {
-            if (!props.id) return null
-            const portal = PortalMap.get(props.id)
+            if (!protalId) return null
+            const portal = PortalMap.get(protalId)
             if (portal) return createPortal(portal, document.body)
             return null
           }}
         </Observer>
       </Fragment>
     )
-  }
-  Portal.defaultProps = {
-    id,
   }
   return Portal
 }

--- a/packages/next/src/__builtins__/portal.tsx
+++ b/packages/next/src/__builtins__/portal.tsx
@@ -11,9 +11,9 @@ const PortalMap = observable(new Map<string | symbol, React.ReactNode>())
 
 export const createPortalProvider = (id: string | symbol) => {
   const Portal = (props: React.PropsWithChildren<IPortalProps>) => {
-    const protalId = id
-    if (protalId && !PortalMap.has(protalId)) {
-      PortalMap.set(protalId, null)
+    const portalId = props.id ?? id
+    if (portalId && !PortalMap.has(portalId)) {
+      PortalMap.set(portalId, null)
     }
 
     return (
@@ -21,8 +21,8 @@ export const createPortalProvider = (id: string | symbol) => {
         {props.children}
         <Observer>
           {() => {
-            if (!protalId) return null
-            const portal = PortalMap.get(protalId)
+            if (!portalId) return null
+            const portal = PortalMap.get(portalId)
             if (portal) return createPortal(portal, document.body)
             return null
           }}

--- a/packages/next/src/array-collapse/index.tsx
+++ b/packages/next/src/array-collapse/index.tsx
@@ -73,7 +73,7 @@ const insertExpandedKeys = (expandedKeys: number[], index: number) => {
 }
 
 export const ArrayCollapse: ComposedArrayCollapse = observer(
-  ({ defaultOpenPanelCount, ...props }) => {
+  ({ defaultOpenPanelCount = 5, ...props }) => {
     const field = useField<ArrayField>()
     const dataSource = Array.isArray(field.value) ? field.value : []
 
@@ -233,9 +233,6 @@ const CollapsePanel: React.FC<React.PropsWithChildren<PanelProps>> = ({
 
 CollapsePanel.displayName = 'CollapsePanel'
 
-ArrayCollapse.defaultProps = {
-  defaultOpenPanelCount: 5,
-}
 ArrayCollapse.displayName = 'ArrayCollapse'
 ArrayCollapse.CollapsePanel = CollapsePanel
 

--- a/packages/next/src/form-button-group/index.tsx
+++ b/packages/next/src/form-button-group/index.tsx
@@ -56,7 +56,7 @@ function getDefaultBackground() {
 }
 
 export const FormButtonGroup: ComposedButtonGroup = ({
-  align,
+  align = 'left',
   gutter,
   ...props
 }) => {
@@ -82,10 +82,6 @@ export const FormButtonGroup: ComposedButtonGroup = ({
   )
 }
 
-FormButtonGroup.defaultProps = {
-  align: 'left',
-}
-
 FormButtonGroup.FormItem = ({ gutter, ...props }) => {
   return (
     <BaseItem
@@ -108,7 +104,7 @@ FormButtonGroup.FormItem = ({ gutter, ...props }) => {
   )
 }
 
-FormButtonGroup.Sticky = ({ align, ...props }) => {
+FormButtonGroup.Sticky = ({ align = 'left', ...props }) => {
   const ref = useRef()
   const [color, setColor] = useState('transparent')
   const prefixCls = usePrefixCls('formily-button-group')
@@ -148,10 +144,6 @@ FormButtonGroup.Sticky = ({ align, ...props }) => {
       </div>
     </StickyBox>
   )
-}
-
-FormButtonGroup.Sticky.defaultProps = {
-  align: 'left',
 }
 
 export default FormButtonGroup

--- a/packages/next/src/form-grid/index.tsx
+++ b/packages/next/src/form-grid/index.tsx
@@ -100,17 +100,13 @@ export const FormGrid: ComposedFormGrid = observer(
 ) as any
 
 export const GridColumn: React.FC<React.PropsWithChildren<IGridColumnProps>> =
-  observer(({ gridSpan, children, ...props }) => {
+  observer(({ gridSpan = 1, children, ...props }) => {
     return (
       <div {...props} data-grid-span={gridSpan}>
         {children}
       </div>
     )
   })
-
-GridColumn.defaultProps = {
-  gridSpan: 1,
-}
 
 FormGrid.createFormGrid = createFormGrid
 FormGrid.useFormGrid = useFormGrid

--- a/packages/next/src/form-item/index.tsx
+++ b/packages/next/src/form-item/index.tsx
@@ -144,7 +144,7 @@ export const BaseItem: React.FC<React.PropsWithChildren<IFormItemProps>> = (
     feedbackStatus,
     extra,
     feedbackText,
-    fullness,
+    fullness = true,
     feedbackLayout,
     feedbackIcon,
     inset,
@@ -420,10 +420,6 @@ export const FormItem: ComposeFormItem = connect(
     }
   })
 )
-
-FormItem.defaultProps = {
-  fullness: true,
-}
 
 FormItem.BaseItem = BaseItem
 

--- a/packages/next/src/form-layout/index.tsx
+++ b/packages/next/src/form-layout/index.tsx
@@ -65,7 +65,7 @@ export const FormLayout: React.FC<React.PropsWithChildren<IFormLayoutProps>> & {
   useFormLayout: () => IFormLayoutContext
   useFormDeepLayout: () => IFormLayoutContext
   useFormShallowLayout: () => IFormLayoutContext
-} = ({ shallow, children, prefix, className, style, ...otherProps }) => {
+} = ({ shallow = true, children, prefix, className, style, ...otherProps }) => {
   const { ref, props } = useResponsiveFormLayout(otherProps)
   const deepLayout = useFormDeepLayout()
   const formPrefixCls = usePrefixCls('form', { prefix })
@@ -106,10 +106,6 @@ export const FormLayout: React.FC<React.PropsWithChildren<IFormLayoutProps>> & {
       {renderChildren()}
     </div>
   )
-}
-
-FormLayout.defaultProps = {
-  shallow: true,
 }
 
 FormLayout.useFormDeepLayout = useFormDeepLayout

--- a/packages/next/src/form/index.tsx
+++ b/packages/next/src/form/index.tsx
@@ -20,7 +20,7 @@ export interface FormProps extends IFormLayoutProps {
 
 export const Form: React.FC<React.PropsWithChildren<FormProps>> = ({
   form,
-  component,
+  component = 'form',
   onAutoSubmit,
   onAutoSubmitFailed,
   previewTextPlaceholder,
@@ -56,10 +56,6 @@ export const Form: React.FC<React.PropsWithChildren<FormProps>> = ({
     return <FormProvider form={form}>{renderContent(form)}</FormProvider>
   if (!top) throw new Error('must pass form instance by createForm')
   return renderContent(top)
-}
-
-Form.defaultProps = {
-  component: 'form',
 }
 
 export default Form

--- a/packages/next/src/select-table/index.tsx
+++ b/packages/next/src/select-table/index.tsx
@@ -144,11 +144,11 @@ const addPrimaryKey = (dataSource, rowKey, primaryKey) =>
 
 export const SelectTable: ComposedSelectTable = observer((props) => {
   const {
-    mode,
+    mode = 'multiple',
     dataSource: propsDataSource,
     optionAsValue,
-    valueType,
-    showSearch,
+    valueType = 'all',
+    showSearch = false,
     filterOption,
     filterSort,
     onSearch,
@@ -157,7 +157,7 @@ export const SelectTable: ComposedSelectTable = observer((props) => {
     value,
     onChange,
     rowSelection,
-    primaryKey: rowKey,
+    primaryKey: rowKey = 'key',
     ...otherTableProps
   } = props
   const prefixCls = usePrefixCls('formily-select-table', props)
@@ -393,12 +393,5 @@ const TableColumn: React.FC<
 > = () => <></>
 
 SelectTable.Column = TableColumn
-
-SelectTable.defaultProps = {
-  showSearch: false,
-  valueType: 'all',
-  primaryKey: 'key',
-  mode: 'multiple',
-}
 
 export default SelectTable

--- a/packages/next/src/space/index.tsx
+++ b/packages/next/src/space/index.tsx
@@ -21,9 +21,9 @@ const spaceSize = {
 }
 
 export const Space: React.FC<React.PropsWithChildren<ISpaceProps>> = ({
-  direction,
+  direction = 'horizontal',
   size,
-  align,
+  align = 'start',
   ...props
 }) => {
   const layout = useFormLayout()
@@ -65,11 +65,6 @@ export const Space: React.FC<React.PropsWithChildren<ISpaceProps>> = ({
       ))}
     </Box>
   )
-}
-
-Space.defaultProps = {
-  direction: 'horizontal',
-  align: 'start',
 }
 
 export default Space


### PR DESCRIPTION
React 19 环境下, Form 组件 component 无法获取到 form (因为 function 组件的 defaultProps 属性被废弃), 造成渲染失败

#4254 

_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

修复在 React 19 环境中 defaultProps 失效问题, 这是 19 的一个 BreakChange, 将  defaultProps 替换为ES6 参数默认赋值;  


React 19 Upgrade Guide [Removed: propTypes and defaultProps for functions](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops)

https://codesandbox.io/p/sandbox/tgnf4j
