### PR TITLE
fix(formily grid): add requestAnimationFrame to smooth grid digest and avoid frequent observer triggering

### DIFF
--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -440,7 +440,13 @@ export class Grid<Container extends HTMLElement> {
         }
       })
       const mutationObserver = new ChildListMutationObserver(digest)
-      const resizeObserver = new ResizeObserver(digest)
+      // add requestAnimationFrame to smooth digest
+      const smoothDigest = () => {
+        requestAnimationFrame(() => {
+          digest()
+        })
+      }
+      const resizeObserver = new ResizeObserver(smoothDigest)
       const dispose = reaction(() => ({ ...this.options }), digest)
       resizeObserver.observe(this.container)
       mutationObserver.observe(this.container, {


### PR DESCRIPTION
fix “ResizeObserver loop completed with undelivered notifications” issue

Before submitting a pull request, please make sure the following is done...

[✅] Ensure the pull request title and commit message follow the Commit Specific in English.
[✅] Fork the repo and create your branch from master or formily_next.
[✅] If you've added code that should be tested, add tests!
[✅] If you've changed APIs, update the documentation.
[✅] Ensure the test suite passes (npm test).
[✅] Make sure your code lints (npm run lint) - we've done our best to make sure these rules match our internal linting guidelines.
Please do not delete the above content

**Please do not delete the above content**

---

## What have you changed?
add requestAnimationFrame to smooth grid digest and avoid frequent observer triggering