### PR TITLE
fix(core): avoid arrayField spliceArrayState removing unexcepted fields

### DIFF
--- a/packages/core/src/__tests__/array.spec.ts
+++ b/packages/core/src/__tests__/array.spec.ts
@@ -1122,3 +1122,43 @@ test('record: find form fields', () => {
 
   expect(array.record).toEqual({ array: [{ a: 1 }, { a: 2 }] })
 })
+
+test('array field splice array state should not destory unexpected field', () => {
+  const form = attach(
+    createForm({
+      initialValues: {
+        array: [{ a: 1 }, { a: 2 }, { a: 3 }],
+      },
+    })
+  )
+
+  const array = attach(
+    form.createArrayField({
+      name: 'array',
+    })
+  )
+  attach(
+    form.createField({
+      name: '0',
+      basePath: 'array',
+    })
+  )
+  attach(
+    form.createField({
+      name: '1',
+      basePath: 'array',
+    })
+  )
+  attach(
+    form.createField({
+      name: '2',
+      basePath: 'array',
+    })
+  )
+
+  array.remove(0)
+
+  array.remove(0)
+
+  expect(Object.keys(form.fields)).toEqual(['array', 'array.0'])
+})

--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -154,7 +154,17 @@ export const patchFieldStates = (
 ) => {
   patches.forEach(({ type, address, oldAddress, payload }) => {
     if (type === 'remove') {
-      destroy(target, address, false)
+      if (payload) {
+        // When a payload is passed, the node should be deleted. However, the address may still be used.
+        // To avoid affecting the address order, set address to undefined.
+        destroyField(payload, false)
+        if (target[address] === payload) {
+          target[address] = undefined
+        }
+      } else {
+        // If only the address is passed without the payload, it means that the address is no longer used, so remove the address directly
+        delete target[address]
+      }
     } else if (type === 'update') {
       if (payload) {
         target[address] = payload
@@ -169,18 +179,24 @@ export const patchFieldStates = (
   })
 }
 
+export const destroyField = (field: GeneralField, forceClear = true) => {
+  field.dispose()
+  if (isDataField(field) && forceClear) {
+    const form = field.form
+    const path = field.path
+    form.deleteValuesIn(path)
+    form.deleteInitialValuesIn(path)
+  }
+}
+
 export const destroy = (
   target: Record<string, GeneralField>,
   address: string,
   forceClear = true
 ) => {
   const field = target[address]
-  field?.dispose()
-  if (isDataField(field) && forceClear) {
-    const form = field.form
-    const path = field.path
-    form.deleteValuesIn(path)
-    form.deleteInitialValuesIn(path)
+  if (field) {
+    destroyField(field, forceClear)
   }
   delete target[address]
 }
@@ -383,19 +399,27 @@ export const spliceArrayState = (
     return index >= startIndex && index < startIndex + insertCount
   }
   const isDeleteNode = (identifier: string) => {
+    const afterStr = identifier.substring(addrLength)
+    const number = afterStr.match(NumberIndexReg)?.[1]
+    if (number === undefined) return false
+    const index = Number(number)
+    return index >= startIndex && index < startIndex + deleteCount
+  }
+
+  const isNeedCleanupNode = (identifier: string) => {
     const preStr = identifier.substring(0, addrLength)
     const afterStr = identifier.substring(addrLength)
     const number = afterStr.match(NumberIndexReg)?.[1]
     if (number === undefined) return false
     const index = Number(number)
     return (
-      (index > startIndex &&
-        !fields[
-          `${preStr}${afterStr.replace(/^\.\d+/, `.${index + deleteCount}`)}`
-        ]) ||
-      index === startIndex
+      index >= startIndex &&
+      !fields[
+        `${preStr}${afterStr.replace(/^\.\d+/, `.${index + deleteCount}`)}`
+      ]
     )
   }
+
   const moveIndex = (identifier: string) => {
     if (offset === 0) return identifier
     const preStr = identifier.substring(0, addrLength)
@@ -417,9 +441,29 @@ export const spliceArrayState = (
             oldAddress: identifier,
             payload: field,
           })
-        }
-        if (isInsertNode(identifier) || isDeleteNode(identifier)) {
-          fieldPatches.push({ type: 'remove', address: identifier })
+          if (isNeedCleanupNode(identifier)) {
+            fieldPatches.push({
+              type: 'remove',
+              address: identifier,
+            })
+          }
+        } else if (isInsertNode(identifier)) {
+          fieldPatches.push({
+            type: 'remove',
+            address: identifier,
+          })
+        } else if (isDeleteNode(identifier)) {
+          fieldPatches.push({
+            type: 'remove',
+            address: identifier,
+            payload: field,
+          })
+          if (isNeedCleanupNode(identifier)) {
+            fieldPatches.push({
+              type: 'remove',
+              address: identifier,
+            })
+          }
         }
       }
     })


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [✅] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [✅] Fork the repo and create your branch from `master` or `formily_next`.
- [✅] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [✅] Ensure the test suite passes (`npm test`).
- [✅] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

修复 ArrayField 状态转置非预期的情况。
比如一个数组有以下字段 array.0 array.1 array.2
在移除第一个元素时，会触发 array.0 的移除，array.1 -> array.0 array.2 -> array.1
在这一步中 address  array.0 会先被 delete 再添加，字段遍历顺序会变更。
再次执行移除第一个元素，此时会先遍历 array.1 再遍历 array.0，这一步会触发 array.1 -> array.0 ，delete array.0 
导致所有字段被删除。

修复方法：
在状态转置中，将删除 field 和删除 field 的 address 分成两种情况处理，field 被删除时可能其 address 不会被删除。
分开处理两种情况，第一种只删除 field 不删除 address，第二种只删除 address。
确保 address 顺序不变，同时确保这里的执行结果和遍历顺序无关。
```js
  const isDeleteNode = (identifier: string) => {
    const afterStr = identifier.substring(addrLength)
    const number = afterStr.match(NumberIndexReg)?.[1]
    if (number === undefined) return false
    const index = Number(number)
    return index >= startIndex && index < startIndex + deleteCount
  }

  const isNeedCleanupNode = (identifier: string) => {
    const preStr = identifier.substring(0, addrLength)
    const afterStr = identifier.substring(addrLength)
    const number = afterStr.match(NumberIndexReg)?.[1]
    if (number === undefined) return false
    const index = Number(number)
    return (
      index >= startIndex &&
      !fields[
        `${preStr}${afterStr.replace(/^\.\d+/, `.${index + deleteCount}`)}`
      ]
    )
  }
```

