### PR TITLE
fix(reactive): avoid unneccessary reaction

### DIFF
--- a/packages/reactive/src/__tests__/autorun.spec.ts
+++ b/packages/reactive/src/__tests__/autorun.spec.ts
@@ -741,3 +741,19 @@ test('reaction recollect dependencies', () => {
   expect(fn2).toBeCalledTimes(2)
   expect(trigger2).toBeCalledTimes(2)
 })
+
+test('avoid unnecessary reaction', () => {
+  const obs = observable<any>({
+    aa: { v: 1 },
+  })
+  const fn1 = jest.fn()
+
+  reaction(() => {
+    fn1()
+    return obs.aa.v
+  })
+
+  obs.aa = obs.aa
+
+  expect(fn1).toBeCalledTimes(1)
+})

--- a/packages/reactive/src/handlers.ts
+++ b/packages/reactive/src/handlers.ts
@@ -207,7 +207,12 @@ export const baseHandlers: ProxyHandler<any> = {
     }
     const hadKey = hasOwnProperty.call(target, key)
     const newValue = createObservable(target, key, value)
-    const oldValue = target[key]
+
+    // If the old value has already generated an observable result,
+    // directly use observableResult compapre to value to avoid unnecessary reactions
+    const observableResult = RawProxy.get(target[key])
+    const oldValue = observableResult ? observableResult : target[key]
+
     target[key] = newValue // use Reflect.set is too slow
     if (!hadKey) {
       runReactionsFromTargetKey({


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ✅] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [ ✅] Fork the repo and create your branch from `master` or `formily_next`.
- [✅ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ✅] Ensure the test suite passes (`npm test`).
- [ ✅] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

如果 object 上的某个 key 已经生成 observableResult，get 的值应该就是 observableResult，但是因为没有 set，内部对象值还是 plainobject，在 set 自己时会额外 reaction 一次（某些情况下会导致 react 额外渲染一次）

避免不必要的 reaction