### PR TITLE
perf(reactive): optimize arrayField performance, achieving precise rendering with array transposition

### DIFF
--- a/packages/core/src/__tests__/array.spec.ts
+++ b/packages/core/src/__tests__/array.spec.ts
@@ -1122,3 +1122,43 @@ test('record: find form fields', () => {
 
   expect(array.record).toEqual({ array: [{ a: 1 }, { a: 2 }] })
 })
+
+test('array field splice array state should not destory unexpected field', () => {
+  const form = attach(
+    createForm({
+      initialValues: {
+        array: [{ a: 1 }, { a: 2 }, { a: 3 }],
+      },
+    })
+  )
+
+  const array = attach(
+    form.createArrayField({
+      name: 'array',
+    })
+  )
+  attach(
+    form.createField({
+      name: '0',
+      basePath: 'array',
+    })
+  )
+  attach(
+    form.createField({
+      name: '1',
+      basePath: 'array',
+    })
+  )
+  attach(
+    form.createField({
+      name: '2',
+      basePath: 'array',
+    })
+  )
+
+  array.remove(0)
+
+  array.remove(0)
+
+  expect(Object.keys(form.fields)).toEqual(['array', 'array.0'])
+})

--- a/packages/core/src/models/ArrayField.ts
+++ b/packages/core/src/models/ArrayField.ts
@@ -9,11 +9,22 @@ import { Field } from './Field'
 import { Form } from './Form'
 import { JSXComponent, IFieldProps, FormPathPattern } from '../types'
 
+const uniqueIdRef = { current: 0 }
+
+const getUniqueId = () => {
+  return uniqueIdRef.current++
+}
+
+const createIndexKey = () => {
+  return `_$id_${getUniqueId()}_`
+}
+
 export class ArrayField<
   Decorator extends JSXComponent = any,
   Component extends JSXComponent = any
 > extends Field<Decorator, Component, any, any[]> {
   displayName = 'ArrayField'
+  indexKeys: Array<string> = []
 
   constructor(
     address: FormPathPattern,
@@ -22,6 +33,7 @@ export class ArrayField<
     designable: boolean
   ) {
     super(address, props, form, designable)
+    this.indexKeys = []
     this.makeAutoCleanable()
   }
 
@@ -32,20 +44,37 @@ export class ArrayField<
         (newLength, oldLength) => {
           if (oldLength && !newLength) {
             cleanupArrayChildren(this, 0)
+            this.indexKeys = []
           } else if (newLength < oldLength) {
             cleanupArrayChildren(this, newLength)
+            this.indexKeys = this.indexKeys.slice(0, newLength)
           }
         }
       )
     )
   }
 
+  getIndexKey(index: number) {
+    if (!this.indexKeys[index]) {
+      const newKey = createIndexKey()
+      this.indexKeys[index] = newKey
+      return newKey
+    }
+    return this.indexKeys[index]
+  }
+
+  getCurrentKeyIndex(key: string) {
+    return this.indexKeys.indexOf(key)
+  }
+
   push = (...items: any[]) => {
     return action(() => {
       if (!isArr(this.value)) {
         this.value = []
+        this.indexKeys = []
       }
       this.value.push(...items)
+      this.indexKeys.push(...items.map(createIndexKey))
       return this.onInput(this.value)
     })
   }
@@ -59,6 +88,7 @@ export class ArrayField<
         deleteCount: 1,
       })
       this.value.pop()
+      this.indexKeys.pop()
       return this.onInput(this.value)
     })
   }
@@ -67,6 +97,7 @@ export class ArrayField<
     return action(() => {
       if (!isArr(this.value)) {
         this.value = []
+        this.indexKeys = []
       }
       if (items.length === 0) {
         return
@@ -76,6 +107,7 @@ export class ArrayField<
         insertCount: items.length,
       })
       this.value.splice(index, 0, ...items)
+      this.indexKeys.splice(index, 0, ...items.map(createIndexKey))
       return this.onInput(this.value)
     })
   }
@@ -88,6 +120,7 @@ export class ArrayField<
         deleteCount: 1,
       })
       this.value.splice(index, 1)
+      this.indexKeys.splice(index, 1)
       return this.onInput(this.value)
     })
   }
@@ -100,6 +133,7 @@ export class ArrayField<
         deleteCount: 1,
       })
       this.value.shift()
+      this.indexKeys.shift()
       return this.onInput(this.value)
     })
   }
@@ -114,6 +148,7 @@ export class ArrayField<
         insertCount: items.length,
       })
       this.value.unshift(...items)
+      this.indexKeys.unshift(...items.map(createIndexKey))
       return this.onInput(this.value)
     })
   }
@@ -123,6 +158,7 @@ export class ArrayField<
     if (fromIndex === toIndex) return
     return action(() => {
       move(this.value, fromIndex, toIndex)
+      move(this.indexKeys, fromIndex, toIndex)
       exchangeArrayState(this, {
         fromIndex,
         toIndex,

--- a/packages/core/src/models/ArrayField.ts
+++ b/packages/core/src/models/ArrayField.ts
@@ -95,6 +95,10 @@ export class ArrayField<
   shift = () => {
     if (!isArr(this.value)) return
     return action(() => {
+      spliceArrayState(this, {
+        startIndex: 0,
+        deleteCount: 1,
+      })
       this.value.shift()
       return this.onInput(this.value)
     })

--- a/packages/core/src/models/Field.ts
+++ b/packages/core/src/models/Field.ts
@@ -160,6 +160,7 @@ export class Field<
       componentProps: observable,
       validator: observable.shallow,
       data: observable.shallow,
+      parent: observable.computed,
       component: observable.computed,
       decorator: observable.computed,
       errors: observable.computed,

--- a/packages/core/src/models/VoidField.ts
+++ b/packages/core/src/models/VoidField.ts
@@ -80,6 +80,7 @@ export class VoidField<
       data: observable.shallow,
       decoratorProps: observable,
       componentProps: observable,
+      parent: observable.computed,
       display: observable.computed,
       pattern: observable.computed,
       hidden: observable.computed,

--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -154,7 +154,17 @@ export const patchFieldStates = (
 ) => {
   patches.forEach(({ type, address, oldAddress, payload }) => {
     if (type === 'remove') {
-      destroy(target, address, false)
+      if (payload) {
+        // When a payload is passed, the node should be deleted. However, the address may still be used.
+        // To avoid affecting the address order, set address to undefined.
+        destroyField(payload, false)
+        if (target[address] === payload) {
+          target[address] = undefined
+        }
+      } else {
+        // If only the address is passed without the payload, it means that the address is no longer used, so remove the address directly
+        delete target[address]
+      }
     } else if (type === 'update') {
       if (payload) {
         target[address] = payload
@@ -169,18 +179,24 @@ export const patchFieldStates = (
   })
 }
 
+export const destroyField = (field: GeneralField, forceClear = true) => {
+  field.dispose()
+  if (isDataField(field) && forceClear) {
+    const form = field.form
+    const path = field.path
+    form.deleteValuesIn(path)
+    form.deleteInitialValuesIn(path)
+  }
+}
+
 export const destroy = (
   target: Record<string, GeneralField>,
   address: string,
   forceClear = true
 ) => {
   const field = target[address]
-  field?.dispose()
-  if (isDataField(field) && forceClear) {
-    const form = field.form
-    const path = field.path
-    form.deleteValuesIn(path)
-    form.deleteInitialValuesIn(path)
+  if (field) {
+    destroyField(field, forceClear)
   }
   delete target[address]
 }
@@ -383,19 +399,27 @@ export const spliceArrayState = (
     return index >= startIndex && index < startIndex + insertCount
   }
   const isDeleteNode = (identifier: string) => {
+    const afterStr = identifier.substring(addrLength)
+    const number = afterStr.match(NumberIndexReg)?.[1]
+    if (number === undefined) return false
+    const index = Number(number)
+    return index >= startIndex && index < startIndex + deleteCount
+  }
+
+  const isNeedCleanupNode = (identifier: string) => {
     const preStr = identifier.substring(0, addrLength)
     const afterStr = identifier.substring(addrLength)
     const number = afterStr.match(NumberIndexReg)?.[1]
     if (number === undefined) return false
     const index = Number(number)
     return (
-      (index > startIndex &&
-        !fields[
-          `${preStr}${afterStr.replace(/^\.\d+/, `.${index + deleteCount}`)}`
-        ]) ||
-      index === startIndex
+      index >= startIndex &&
+      !fields[
+        `${preStr}${afterStr.replace(/^\.\d+/, `.${index + deleteCount}`)}`
+      ]
     )
   }
+
   const moveIndex = (identifier: string) => {
     if (offset === 0) return identifier
     const preStr = identifier.substring(0, addrLength)
@@ -417,9 +441,29 @@ export const spliceArrayState = (
             oldAddress: identifier,
             payload: field,
           })
-        }
-        if (isInsertNode(identifier) || isDeleteNode(identifier)) {
-          fieldPatches.push({ type: 'remove', address: identifier })
+          if (isNeedCleanupNode(identifier)) {
+            fieldPatches.push({
+              type: 'remove',
+              address: identifier,
+            })
+          }
+        } else if (isInsertNode(identifier)) {
+          fieldPatches.push({
+            type: 'remove',
+            address: identifier,
+          })
+        } else if (isDeleteNode(identifier)) {
+          fieldPatches.push({
+            type: 'remove',
+            address: identifier,
+            payload: field,
+          })
+          if (isNeedCleanupNode(identifier)) {
+            fieldPatches.push({
+              type: 'remove',
+              address: identifier,
+            })
+          }
         }
       }
     })

--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -152,7 +152,7 @@ export const patchFieldStates = (
   target: Record<string, GeneralField>,
   patches: INodePatch<GeneralField>[]
 ) => {
-  patches.forEach(({ type, address, oldAddress, payload }) => {
+  patches.forEach(({ type, address, oldAddress, payload, oldPayload }) => {
     if (type === 'remove') {
       if (payload) {
         // When a payload is passed, the node should be deleted. However, the address may still be used.
@@ -173,7 +173,12 @@ export const patchFieldStates = (
         }
       }
       if (address && payload) {
-        locateNode(payload, address)
+        if (oldPayload) {
+          payload.address = oldPayload.address
+          payload.path = oldPayload.path
+        } else {
+          locateNode(payload, address)
+        }
       }
     }
   })
@@ -440,6 +445,12 @@ export const spliceArrayState = (
             address: newIdentifier,
             oldAddress: identifier,
             payload: field,
+            oldPayload: fields[newIdentifier]
+              ? {
+                  address: fields[newIdentifier].address,
+                  path: fields[newIdentifier].path,
+                }
+              : undefined,
           })
           if (isNeedCleanupNode(identifier)) {
             fieldPatches.push({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -111,6 +111,7 @@ export interface INodePatch<T> {
   address: string
   oldAddress?: string
   payload?: T
+  oldPayload?: Partial<T>
 }
 
 export interface IHeartProps<Context> {

--- a/packages/react/docs/api/components/ArrayField.md
+++ b/packages/react/docs/api/components/ArrayField.md
@@ -40,7 +40,10 @@ const ArrayComponent = observer(() => {
     <>
       <div>
         {field.value?.map((item, index) => (
-          <div key={index} style={{ display: 'flex-block', marginBottom: 10 }}>
+          <div
+            key={field.getIndexKey(index)}
+            style={{ display: 'flex-block', marginBottom: 10 }}
+          >
             <Space>
               <Field name={index} component={[Input]} />
               <Button
@@ -105,7 +108,7 @@ export default () => (
             <div>
               {field.value?.map((item, index) => (
                 <div
-                  key={index}
+                  key={field.getIndexKey(index)}
                   style={{ display: 'flex-block', marginBottom: 10 }}
                 >
                   <Space>

--- a/packages/react/docs/api/components/ArrayField.zh-CN.md
+++ b/packages/react/docs/api/components/ArrayField.zh-CN.md
@@ -40,7 +40,10 @@ const ArrayComponent = observer(() => {
     <>
       <div>
         {field.value?.map((item, index) => (
-          <div key={index} style={{ display: 'flex-block', marginBottom: 10 }}>
+          <div
+            key={field.getIndexKey(index)}
+            style={{ display: 'flex-block', marginBottom: 10 }}
+          >
             <Space>
               <Field name={index} component={[Input]} />
               <Button
@@ -105,7 +108,7 @@ export default () => (
             <div>
               {field.value?.map((item, index) => (
                 <div
-                  key={index}
+                  key={field.getIndexKey(index)}
                   style={{ display: 'flex-block', marginBottom: 10 }}
                 >
                   <Space>

--- a/packages/react/docs/api/components/RecursionField.md
+++ b/packages/react/docs/api/components/RecursionField.md
@@ -97,7 +97,7 @@ const ArrayItems = observer((props) => {
     <div>
       {props.value?.map((item, index) => {
         return (
-          <div key={index} style={{ marginBottom: 10 }}>
+          <div key={field.getIndexKey(index)} style={{ marginBottom: 10 }}>
             <Space>
               <RecursionField schema={schema.items} name={index} />
               <Button

--- a/packages/react/docs/api/components/RecursionField.zh-CN.md
+++ b/packages/react/docs/api/components/RecursionField.zh-CN.md
@@ -97,7 +97,7 @@ const ArrayItems = observer((props) => {
     <div>
       {props.value?.map((item, index) => {
         return (
-          <div key={index} style={{ marginBottom: 10 }}>
+          <div key={field.getIndexKey(index)} style={{ marginBottom: 10 }}>
             <Space>
               <RecursionField schema={schema.items} name={index} />
               <Button

--- a/packages/reactive/src/__tests__/autorun.spec.ts
+++ b/packages/reactive/src/__tests__/autorun.spec.ts
@@ -741,3 +741,19 @@ test('reaction recollect dependencies', () => {
   expect(fn2).toBeCalledTimes(2)
   expect(trigger2).toBeCalledTimes(2)
 })
+
+test('avoid unnecessary reaction', () => {
+  const obs = observable<any>({
+    aa: { v: 1 },
+  })
+  const fn1 = jest.fn()
+
+  reaction(() => {
+    fn1()
+    return obs.aa.v
+  })
+
+  obs.aa = obs.aa
+
+  expect(fn1).toBeCalledTimes(1)
+})

--- a/packages/reactive/src/annotations/computed.ts
+++ b/packages/reactive/src/annotations/computed.ts
@@ -1,4 +1,9 @@
-import { ObModelSymbol, ReactionStack } from '../environment'
+import {
+  ObModelSymbol,
+  PendingComputedReactions,
+  PendingScopeComputedReactions,
+  ReactionStack,
+} from '../environment'
 import { createAnnotation } from '../internals'
 import { buildDataTree } from '../tree'
 import { isFn } from '../checkers'
@@ -13,6 +18,7 @@ import {
   releaseBindingReactions,
   getReactionsFromTargetKey,
 } from '../reaction'
+import { Reaction } from '../types'
 
 interface IValue<T = any> {
   value?: T
@@ -68,6 +74,13 @@ function getPrototypeDescriptor(
   return {}
 }
 
+const isAllComputedDeps = (reaction: Reaction) => {
+  if (!reaction._isComputed) return false
+  const deps = getReactionsFromTargetKey(reaction._context, reaction._property)
+  if (!deps.length) return true
+  return deps.every((dep) => isAllComputedDeps(dep))
+}
+
 export const computed: IComputed = createAnnotation(
   ({ target, key, value }) => {
     const store: IValue = {}
@@ -95,9 +108,6 @@ export const computed: IComputed = createAnnotation(
 
     reaction._name = 'ComputedReaction'
     reaction._scheduler = () => {
-      if (!reaction._dirty_scheduler) return
-      reaction._dirty_scheduler = false
-
       if (!reaction._dirty) {
         runReactionsFromTargetKey({
           target: context,
@@ -112,7 +122,7 @@ export const computed: IComputed = createAnnotation(
 
       if (!deps.length) return
 
-      if (deps.every((dep) => dep._isComputed)) {
+      if (deps.every((dep) => isAllComputedDeps(dep))) {
         // all deps are computed reactions, so should dirty the upstream computed reactions
         runReactionsFromTargetKey({
           target: context,
@@ -140,8 +150,6 @@ export const computed: IComputed = createAnnotation(
     reaction._isComputed = true
     // is need to re calculate
     reaction._dirty = true
-    // is need to schedule to notice upstream reactions
-    reaction._dirty_scheduler = true
     reaction._context = context
     reaction._property = property
 
@@ -157,9 +165,10 @@ export const computed: IComputed = createAnnotation(
           reaction()
           reaction._dirty = false
           const newValue = store.value
-          if (newValue === currentValue) {
-            // no need to schedule
-            reaction._dirty_scheduler = false
+          if (newValue !== currentValue) {
+            // if the value is changed, it should be scheduled
+            PendingComputedReactions.update(reaction)
+            PendingScopeComputedReactions.update(reaction)
           }
         }
         bindTargetKeyWithCurrentReaction({

--- a/packages/reactive/src/annotations/computed.ts
+++ b/packages/reactive/src/annotations/computed.ts
@@ -11,6 +11,7 @@ import {
   batchStart,
   batchEnd,
   releaseBindingReactions,
+  getReactionsFromTargetKey,
 } from '../reaction'
 
 interface IValue<T = any> {
@@ -91,18 +92,56 @@ export const computed: IComputed = createAnnotation(
         }
       }
     }
+
     reaction._name = 'ComputedReaction'
     reaction._scheduler = () => {
-      reaction._dirty = true
-      runReactionsFromTargetKey({
-        target: context,
-        key: property,
-        value: store.value,
-        type: 'set',
-      })
+      if (!reaction._dirty_scheduler) return
+      reaction._dirty_scheduler = false
+
+      if (!reaction._dirty) {
+        runReactionsFromTargetKey({
+          target: context,
+          key: property,
+          value: store.value,
+          type: 'set',
+        })
+        return
+      }
+
+      const deps = getReactionsFromTargetKey(context, property)
+
+      if (!deps.length) return
+
+      if (deps.every((dep) => dep._isComputed)) {
+        // all deps are computed reactions, so should dirty the upstream computed reactions
+        runReactionsFromTargetKey({
+          target: context,
+          key: property,
+          value: store.value,
+          type: 'set',
+        })
+        return
+      }
+
+      const currentValue = store.value
+      reaction()
+      reaction._dirty = false
+      const newValue = store.value
+      if (newValue !== currentValue) {
+        runReactionsFromTargetKey({
+          target: context,
+          key: property,
+          value: store.value,
+          type: 'set',
+        })
+      }
     }
+
     reaction._isComputed = true
+    // is need to re calculate
     reaction._dirty = true
+    // is need to schedule to notice upstream reactions
+    reaction._dirty_scheduler = true
     reaction._context = context
     reaction._property = property
 
@@ -113,18 +152,25 @@ export const computed: IComputed = createAnnotation(
       if (!isUntracking()) {
         //如果允许untracked过程中收集依赖，那么永远不会存在绑定，因为_dirty已经设置为false
         if (reaction._dirty) {
+          // if the value is used in batch function, it will directly execute and set dirty to false
+          const currentValue = store.value
           reaction()
           reaction._dirty = false
+          const newValue = store.value
+          if (newValue === currentValue) {
+            // no need to schedule
+            reaction._dirty_scheduler = false
+          }
         }
-      } else {
-        compute()
+        bindTargetKeyWithCurrentReaction({
+          target: context,
+          key: property,
+          type: 'get',
+        })
+        return store.value
       }
-      bindTargetKeyWithCurrentReaction({
-        target: context,
-        key: property,
-        type: 'get',
-      })
-      return store.value
+
+      return descriptor.get?.call(context)
     }
 
     function set(value: any) {

--- a/packages/reactive/src/environment.ts
+++ b/packages/reactive/src/environment.ts
@@ -1,5 +1,6 @@
 import { ObservableListener, Reaction, ReactionsMap } from './types'
 import { ArraySet } from './array'
+import { ReactionsArraySet } from './reactions-array-set'
 import { DataNode } from './tree'
 
 export const ProxyRaw = new WeakMap()
@@ -13,10 +14,10 @@ export const BatchCount = { value: 0 }
 export const UntrackCount = { value: 0 }
 export const BatchScope = { value: false }
 export const DependencyCollected = { value: false }
-export const PendingReactions = new ArraySet<Reaction>()
-export const PendingScopeReactions = new ArraySet<Reaction>()
-export const PendingComputedReactions = new ArraySet<Reaction>()
-export const PendingScopeComputedReactions = new ArraySet<Reaction>()
+export const PendingReactions = new ReactionsArraySet<Reaction>()
+export const PendingScopeReactions = new ReactionsArraySet<Reaction>()
+export const PendingComputedReactions = new ReactionsArraySet<Reaction>()
+export const PendingScopeComputedReactions = new ReactionsArraySet<Reaction>()
 export const BatchEndpoints = new ArraySet<() => void>()
 export const ObserverListeners = new ArraySet<ObservableListener>()
 export const MakeObModelSymbol = Symbol('MakeObModelSymbol')

--- a/packages/reactive/src/environment.ts
+++ b/packages/reactive/src/environment.ts
@@ -15,6 +15,8 @@ export const BatchScope = { value: false }
 export const DependencyCollected = { value: false }
 export const PendingReactions = new ArraySet<Reaction>()
 export const PendingScopeReactions = new ArraySet<Reaction>()
+export const PendingComputedReactions = new ArraySet<Reaction>()
+export const PendingScopeComputedReactions = new ArraySet<Reaction>()
 export const BatchEndpoints = new ArraySet<() => void>()
 export const ObserverListeners = new ArraySet<ObservableListener>()
 export const MakeObModelSymbol = Symbol('MakeObModelSymbol')

--- a/packages/reactive/src/handlers.ts
+++ b/packages/reactive/src/handlers.ts
@@ -207,7 +207,12 @@ export const baseHandlers: ProxyHandler<any> = {
     }
     const hadKey = hasOwnProperty.call(target, key)
     const newValue = createObservable(target, key, value)
-    const oldValue = target[key]
+
+    // If the old value has already generated an observable result,
+    // directly use observableResult compapre to value to avoid unnecessary reactions
+    const observableResult = RawProxy.get(target[key])
+    const oldValue = observableResult ? observableResult : target[key]
+
     target[key] = newValue // use Reflect.set is too slow
     if (!hadKey) {
       runReactionsFromTargetKey({

--- a/packages/reactive/src/reaction.ts
+++ b/packages/reactive/src/reaction.ts
@@ -12,6 +12,8 @@ import {
   UntrackCount,
   BatchScope,
   ObserverListeners,
+  PendingComputedReactions,
+  PendingScopeComputedReactions,
 } from './environment'
 
 const ITERATION_KEY = Symbol('iteration key')
@@ -52,7 +54,7 @@ const addReactionsMapToReaction = (
   return bindSet
 }
 
-const getReactionsFromTargetKey = (target: any, key: PropertyKey) => {
+export const getReactionsFromTargetKey = (target: any, key: PropertyKey) => {
   const reactionsMap = RawReactionsMap.get(target)
   const reactions = []
   if (reactionsMap) {
@@ -75,7 +77,15 @@ const runReactions = (target: any, key: PropertyKey) => {
   for (let i = 0, len = reactions.length; i < len; i++) {
     const reaction = reactions[i]
     if (reaction._isComputed) {
-      reaction._scheduler(reaction)
+      reaction._dirty = true
+      reaction._dirty_scheduler = true
+      if (isScopeBatching()) {
+        PendingScopeComputedReactions.add(reaction)
+      } else if (isBatching()) {
+        PendingComputedReactions.add(reaction)
+      } else {
+        reaction._scheduler(reaction)
+      }
     } else if (isScopeBatching()) {
       PendingScopeReactions.add(reaction)
     } else if (isBatching()) {
@@ -182,13 +192,18 @@ export const batchStart = () => {
 }
 
 export const batchEnd = () => {
-  BatchCount.value--
-  if (BatchCount.value === 0) {
+  if (BatchCount.value === 1) {
     const prevUntrackCount = UntrackCount.value
     UntrackCount.value = 0
+    executePendingComputedReactions()
+
+    BatchCount.value--
+
     executePendingReactions()
     executeBatchEndpoints()
     UntrackCount.value = prevUntrackCount
+  } else {
+    BatchCount.value--
   }
 }
 
@@ -198,8 +213,15 @@ export const batchScopeStart = () => {
 
 export const batchScopeEnd = () => {
   const prevUntrackCount = UntrackCount.value
-  BatchScope.value = false
   UntrackCount.value = 0
+
+  PendingScopeComputedReactions.batchDelete((reaction) => {
+    if (isFn(reaction._scheduler)) {
+      reaction._scheduler(reaction)
+    }
+  })
+
+  BatchScope.value = false
   PendingScopeReactions.batchDelete((reaction) => {
     if (isFn(reaction._scheduler)) {
       reaction._scheduler(reaction)
@@ -223,6 +245,14 @@ export const isBatching = () => BatchCount.value > 0
 export const isScopeBatching = () => BatchScope.value
 
 export const isUntracking = () => UntrackCount.value > 0
+
+export const executePendingComputedReactions = () => {
+  PendingComputedReactions.batchDelete((reaction) => {
+    if (isFn(reaction._scheduler)) {
+      reaction._scheduler(reaction)
+    }
+  })
+}
 
 export const executePendingReactions = () => {
   PendingReactions.batchDelete((reaction) => {

--- a/packages/reactive/src/reaction.ts
+++ b/packages/reactive/src/reaction.ts
@@ -1,5 +1,6 @@
 import { isFn } from './checkers'
 import { ArraySet } from './array'
+import { ReactionsArraySet } from './reactions-array-set'
 import { IOperation, ReactionsMap, Reaction, PropertyKey } from './types'
 import {
   ReactionStack,
@@ -28,28 +29,29 @@ const addRawReactionsMap = (
     const reactions = reactionsMap.get(key)
     if (reactions) {
       reactions.add(reaction)
+      return reactions
     } else {
-      reactionsMap.set(key, new ArraySet([reaction]))
+      reactionsMap.set(key, new ReactionsArraySet([reaction]))
+      return reactionsMap.get(key)
     }
-    return reactionsMap
   } else {
     const reactionsMap: ReactionsMap = new Map([
-      [key, new ArraySet([reaction])],
+      [key, new ReactionsArraySet([reaction])],
     ])
     RawReactionsMap.set(target, reactionsMap)
-    return reactionsMap
+    return reactionsMap.get(key)
   }
 }
 
-const addReactionsMapToReaction = (
+const addReactionsSetToReaction = (
   reaction: Reaction,
-  reactionsMap: ReactionsMap
+  reactionsSet: ReactionsArraySet<Reaction>
 ) => {
   const bindSet = reaction._reactionsSet
   if (bindSet) {
-    bindSet.add(reactionsMap)
+    bindSet.add(reactionsSet)
   } else {
-    reaction._reactionsSet = new ArraySet([reactionsMap])
+    reaction._reactionsSet = new ArraySet([reactionsSet])
   }
   return bindSet
 }
@@ -61,9 +63,7 @@ export const getReactionsFromTargetKey = (target: any, key: PropertyKey) => {
     const map = reactionsMap.get(key)
     if (map) {
       map.forEach((reaction) => {
-        if (reactions.indexOf(reaction) === -1) {
-          reactions.push(reaction)
-        }
+        reactions.push(reaction)
       })
     }
   }
@@ -78,7 +78,6 @@ const runReactions = (target: any, key: PropertyKey) => {
     const reaction = reactions[i]
     if (reaction._isComputed) {
       reaction._dirty = true
-      reaction._dirty_scheduler = true
       if (isScopeBatching()) {
         PendingScopeComputedReactions.add(reaction)
       } else if (isBatching()) {
@@ -117,7 +116,7 @@ export const bindTargetKeyWithCurrentReaction = (operation: IOperation) => {
   if (isUntracking()) return
   if (current) {
     DependencyCollected.value = true
-    addReactionsMapToReaction(current, addRawReactionsMap(target, key, current))
+    addReactionsSetToReaction(current, addRawReactionsMap(target, key, current))
   }
 }
 
@@ -158,13 +157,11 @@ export const hasRunningReaction = () => {
 }
 
 export const releaseBindingReactions = (reaction: Reaction) => {
-  reaction._reactionsSet?.forEach((reactionsMap) => {
-    reactionsMap.forEach((reactions) => {
-      reactions.delete(reaction)
-    })
-  })
-  PendingReactions.delete(reaction)
-  PendingScopeReactions.delete(reaction)
+  // delete outdated reaction by _reactionId
+  if (typeof reaction._reactionId !== 'number') {
+    reaction._reactionId = 0
+  } else reaction._reactionId++
+
   delete reaction._reactionsSet
 }
 
@@ -183,6 +180,11 @@ export const suspendComputedReactions = (current: Reaction) => {
 
 export const disposeBindingReactions = (reaction: Reaction) => {
   reaction._disposed = true
+
+  reaction._reactionsSet?.forEach((reactionsSet) => {
+    reactionsSet.delete(reaction)
+  })
+
   releaseBindingReactions(reaction)
   suspendComputedReactions(reaction)
 }

--- a/packages/reactive/src/reactions-array-set.ts
+++ b/packages/reactive/src/reactions-array-set.ts
@@ -1,0 +1,73 @@
+import { Reaction } from './types'
+
+/**
+ * work like arrayset but delete outdated reaction by _reactionId
+ */
+export class ReactionsArraySet<T extends Reaction> {
+  valueSet: Set<T>
+  reactionIdMap: Map<T, number>
+  forEachIndex = 0
+  constructor(value: T[] = []) {
+    this.valueSet = new Set()
+    this.reactionIdMap = new Map()
+    value.forEach((item) => {
+      this.add(item)
+    })
+  }
+
+  add(item: T) {
+    if (!this.has(item)) {
+      this.valueSet.add(item)
+      this.reactionIdMap.set(item, item._reactionId || 0)
+    } else {
+      this.reactionIdMap.set(item, item._reactionId || 0)
+    }
+  }
+
+  has(item: T) {
+    return this.valueSet.has(item)
+  }
+
+  update(item: T) {
+    if (this.valueSet.has(item)) {
+      this.reactionIdMap.set(item, item._reactionId || 0)
+    }
+  }
+
+  delete(item: T) {
+    const size = this.valueSet.size
+    if (size === 0) return
+    this.valueSet.delete(item)
+    this.reactionIdMap.delete(item)
+  }
+
+  forEach(callback: (value: T) => void) {
+    if (this.valueSet.size === 0) return
+    for (const item of this.valueSet) {
+      const reactionId = this.reactionIdMap.get(item)
+      if (reactionId === item._reactionId) {
+        callback(item)
+      } else {
+        this.delete(item)
+      }
+    }
+  }
+
+  batchDelete(callback: (value: T) => void) {
+    if (this.valueSet.size === 0) return
+
+    for (const item of this.valueSet) {
+      const reactionId = this.reactionIdMap.get(item)
+      if (reactionId === item._reactionId) {
+        callback(item)
+      }
+    }
+
+    this.clear()
+  }
+
+  clear() {
+    this.valueSet.clear()
+    this.reactionIdMap.clear()
+  }
+}

--- a/packages/reactive/src/types.ts
+++ b/packages/reactive/src/types.ts
@@ -1,4 +1,5 @@
 import { ArraySet } from './array'
+import { ReactionsArraySet } from './reactions-array-set'
 
 export * from './tree'
 
@@ -69,7 +70,8 @@ export type Reaction = ((...args: any[]) => any) & {
   _disposed?: boolean
   _property?: PropertyKey
   _computesSet?: ArraySet<Reaction>
-  _reactionsSet?: ArraySet<ReactionsMap>
+  _reactionsSet?: ArraySet<ReactionsArraySet<Reaction>>
+  _reactionId?: number
   _scheduler?: (reaction: Reaction) => void
   _memos?: {
     queue: IMemoQueueItem[]
@@ -81,7 +83,7 @@ export type Reaction = ((...args: any[]) => any) & {
   }
 }
 
-export type ReactionsMap = Map<PropertyKey, ArraySet<Reaction>>
+export type ReactionsMap = Map<PropertyKey, ReactionsArraySet<Reaction>>
 
 export interface IReactionOptions<T> {
   name?: string

--- a/packages/vue/docs/demos/api/components/array-field.vue
+++ b/packages/vue/docs/demos/api/components/array-field.vue
@@ -4,7 +4,7 @@
       <template #default="{ field }">
         <div
           v-for="(item, index) in field.value || []"
-          :key="`${item.id}-${index}`"
+          :key="field.getIndexKey(index)"
           :style="{ marginBottom: '10px' }"
         >
           <Space>


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [✅] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [✅] Fork the repo and create your branch from `master` or `formily_next`.
- [✅] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [✅] Ensure the test suite passes (`npm test`).
- [✅] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

ArrayField does not implement precise rendering, any array state transition will cause all children re-rendering.
When the array is large, it is not possible to render accurately by key, resulting in poor performance.
In this MR, I changed the reaction action of computed to ensure that the computed value will not directly trigger the upstream reaction, but only trigger upstream reaction when computed value has changed.

At the same time, the performance of releasing dependencies during reaction execution is also very low. When there are a large number of reactions and computed values, the performance is very poor, and the degradation is very serious as the number increases. The logic of re-collecting dependencies in reaction has been optimized.

All test cases passed.

Therefore, we can achieve a significant performance improvement on arrayField.

Performance compare sandbox:
https://codesandbox.io/p/sandbox/voder-formily-performance-forked-2wlfmc?file=%2Fformily-array-field.tsx%3A26%2C9
