### PR TITLE
fix(reactive): avoid chain reactions missing

### DIFF
--- a/packages/core/src/__tests__/array.spec.ts
+++ b/packages/core/src/__tests__/array.spec.ts
@@ -1122,3 +1122,43 @@ test('record: find form fields', () => {
 
   expect(array.record).toEqual({ array: [{ a: 1 }, { a: 2 }] })
 })
+
+test('array field splice array state should not destory unexpected field', () => {
+  const form = attach(
+    createForm({
+      initialValues: {
+        array: [{ a: 1 }, { a: 2 }, { a: 3 }],
+      },
+    })
+  )
+
+  const array = attach(
+    form.createArrayField({
+      name: 'array',
+    })
+  )
+  attach(
+    form.createField({
+      name: '0',
+      basePath: 'array',
+    })
+  )
+  attach(
+    form.createField({
+      name: '1',
+      basePath: 'array',
+    })
+  )
+  attach(
+    form.createField({
+      name: '2',
+      basePath: 'array',
+    })
+  )
+
+  array.remove(0)
+
+  array.remove(0)
+
+  expect(Object.keys(form.fields)).toEqual(['array', 'array.0'])
+})

--- a/packages/core/src/models/ArrayField.ts
+++ b/packages/core/src/models/ArrayField.ts
@@ -9,11 +9,22 @@ import { Field } from './Field'
 import { Form } from './Form'
 import { JSXComponent, IFieldProps, FormPathPattern } from '../types'
 
+const uniqueIdRef = { current: 0 }
+
+const getUniqueId = () => {
+  return uniqueIdRef.current++
+}
+
+const createIndexKey = () => {
+  return `_$id_${getUniqueId()}_`
+}
+
 export class ArrayField<
   Decorator extends JSXComponent = any,
   Component extends JSXComponent = any
 > extends Field<Decorator, Component, any, any[]> {
   displayName = 'ArrayField'
+  indexKeys: Array<string> = []
 
   constructor(
     address: FormPathPattern,
@@ -22,6 +33,7 @@ export class ArrayField<
     designable: boolean
   ) {
     super(address, props, form, designable)
+    this.indexKeys = []
     this.makeAutoCleanable()
   }
 
@@ -32,20 +44,37 @@ export class ArrayField<
         (newLength, oldLength) => {
           if (oldLength && !newLength) {
             cleanupArrayChildren(this, 0)
+            this.indexKeys = []
           } else if (newLength < oldLength) {
             cleanupArrayChildren(this, newLength)
+            this.indexKeys = this.indexKeys.slice(0, newLength)
           }
         }
       )
     )
   }
 
+  getIndexKey(index: number) {
+    if (!this.indexKeys[index]) {
+      const newKey = createIndexKey()
+      this.indexKeys[index] = newKey
+      return newKey
+    }
+    return this.indexKeys[index]
+  }
+
+  getCurrentKeyIndex(key: string) {
+    return this.indexKeys.indexOf(key)
+  }
+
   push = (...items: any[]) => {
     return action(() => {
       if (!isArr(this.value)) {
         this.value = []
+        this.indexKeys = []
       }
       this.value.push(...items)
+      this.indexKeys.push(...items.map(createIndexKey))
       return this.onInput(this.value)
     })
   }
@@ -59,6 +88,7 @@ export class ArrayField<
         deleteCount: 1,
       })
       this.value.pop()
+      this.indexKeys.pop()
       return this.onInput(this.value)
     })
   }
@@ -67,6 +97,7 @@ export class ArrayField<
     return action(() => {
       if (!isArr(this.value)) {
         this.value = []
+        this.indexKeys = []
       }
       if (items.length === 0) {
         return
@@ -76,6 +107,7 @@ export class ArrayField<
         insertCount: items.length,
       })
       this.value.splice(index, 0, ...items)
+      this.indexKeys.splice(index, 0, ...items.map(createIndexKey))
       return this.onInput(this.value)
     })
   }
@@ -88,6 +120,7 @@ export class ArrayField<
         deleteCount: 1,
       })
       this.value.splice(index, 1)
+      this.indexKeys.splice(index, 1)
       return this.onInput(this.value)
     })
   }
@@ -100,6 +133,7 @@ export class ArrayField<
         deleteCount: 1,
       })
       this.value.shift()
+      this.indexKeys.shift()
       return this.onInput(this.value)
     })
   }
@@ -114,6 +148,7 @@ export class ArrayField<
         insertCount: items.length,
       })
       this.value.unshift(...items)
+      this.indexKeys.unshift(...items.map(createIndexKey))
       return this.onInput(this.value)
     })
   }
@@ -123,6 +158,7 @@ export class ArrayField<
     if (fromIndex === toIndex) return
     return action(() => {
       move(this.value, fromIndex, toIndex)
+      move(this.indexKeys, fromIndex, toIndex)
       exchangeArrayState(this, {
         fromIndex,
         toIndex,

--- a/packages/core/src/models/ArrayField.ts
+++ b/packages/core/src/models/ArrayField.ts
@@ -95,6 +95,10 @@ export class ArrayField<
   shift = () => {
     if (!isArr(this.value)) return
     return action(() => {
+      spliceArrayState(this, {
+        startIndex: 0,
+        deleteCount: 1,
+      })
       this.value.shift()
       return this.onInput(this.value)
     })

--- a/packages/core/src/models/Field.ts
+++ b/packages/core/src/models/Field.ts
@@ -160,6 +160,7 @@ export class Field<
       componentProps: observable,
       validator: observable.shallow,
       data: observable.shallow,
+      parent: observable.computed,
       component: observable.computed,
       decorator: observable.computed,
       errors: observable.computed,

--- a/packages/core/src/models/VoidField.ts
+++ b/packages/core/src/models/VoidField.ts
@@ -80,6 +80,7 @@ export class VoidField<
       data: observable.shallow,
       decoratorProps: observable,
       componentProps: observable,
+      parent: observable.computed,
       display: observable.computed,
       pattern: observable.computed,
       hidden: observable.computed,

--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -154,7 +154,17 @@ export const patchFieldStates = (
 ) => {
   patches.forEach(({ type, address, oldAddress, payload }) => {
     if (type === 'remove') {
-      destroy(target, address, false)
+      if (payload) {
+        // When a payload is passed, the node should be deleted. However, the address may still be used.
+        // To avoid affecting the address order, set address to undefined.
+        destroyField(payload, false)
+        if (target[address] === payload) {
+          target[address] = undefined
+        }
+      } else {
+        // If only the address is passed without the payload, it means that the address is no longer used, so remove the address directly
+        delete target[address]
+      }
     } else if (type === 'update') {
       if (payload) {
         target[address] = payload
@@ -169,18 +179,24 @@ export const patchFieldStates = (
   })
 }
 
+export const destroyField = (field: GeneralField, forceClear = true) => {
+  field.dispose()
+  if (isDataField(field) && forceClear) {
+    const form = field.form
+    const path = field.path
+    form.deleteValuesIn(path)
+    form.deleteInitialValuesIn(path)
+  }
+}
+
 export const destroy = (
   target: Record<string, GeneralField>,
   address: string,
   forceClear = true
 ) => {
   const field = target[address]
-  field?.dispose()
-  if (isDataField(field) && forceClear) {
-    const form = field.form
-    const path = field.path
-    form.deleteValuesIn(path)
-    form.deleteInitialValuesIn(path)
+  if (field) {
+    destroyField(field, forceClear)
   }
   delete target[address]
 }
@@ -383,19 +399,27 @@ export const spliceArrayState = (
     return index >= startIndex && index < startIndex + insertCount
   }
   const isDeleteNode = (identifier: string) => {
+    const afterStr = identifier.substring(addrLength)
+    const number = afterStr.match(NumberIndexReg)?.[1]
+    if (number === undefined) return false
+    const index = Number(number)
+    return index >= startIndex && index < startIndex + deleteCount
+  }
+
+  const isNeedCleanupNode = (identifier: string) => {
     const preStr = identifier.substring(0, addrLength)
     const afterStr = identifier.substring(addrLength)
     const number = afterStr.match(NumberIndexReg)?.[1]
     if (number === undefined) return false
     const index = Number(number)
     return (
-      (index > startIndex &&
-        !fields[
-          `${preStr}${afterStr.replace(/^\.\d+/, `.${index + deleteCount}`)}`
-        ]) ||
-      index === startIndex
+      index >= startIndex &&
+      !fields[
+        `${preStr}${afterStr.replace(/^\.\d+/, `.${index + deleteCount}`)}`
+      ]
     )
   }
+
   const moveIndex = (identifier: string) => {
     if (offset === 0) return identifier
     const preStr = identifier.substring(0, addrLength)
@@ -417,9 +441,29 @@ export const spliceArrayState = (
             oldAddress: identifier,
             payload: field,
           })
-        }
-        if (isInsertNode(identifier) || isDeleteNode(identifier)) {
-          fieldPatches.push({ type: 'remove', address: identifier })
+          if (isNeedCleanupNode(identifier)) {
+            fieldPatches.push({
+              type: 'remove',
+              address: identifier,
+            })
+          }
+        } else if (isInsertNode(identifier)) {
+          fieldPatches.push({
+            type: 'remove',
+            address: identifier,
+          })
+        } else if (isDeleteNode(identifier)) {
+          fieldPatches.push({
+            type: 'remove',
+            address: identifier,
+            payload: field,
+          })
+          if (isNeedCleanupNode(identifier)) {
+            fieldPatches.push({
+              type: 'remove',
+              address: identifier,
+            })
+          }
         }
       }
     })

--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -152,7 +152,7 @@ export const patchFieldStates = (
   target: Record<string, GeneralField>,
   patches: INodePatch<GeneralField>[]
 ) => {
-  patches.forEach(({ type, address, oldAddress, payload }) => {
+  patches.forEach(({ type, address, oldAddress, payload, oldPayload }) => {
     if (type === 'remove') {
       if (payload) {
         // When a payload is passed, the node should be deleted. However, the address may still be used.
@@ -173,7 +173,12 @@ export const patchFieldStates = (
         }
       }
       if (address && payload) {
-        locateNode(payload, address)
+        if (oldPayload) {
+          payload.address = oldPayload.address
+          payload.path = oldPayload.path
+        } else {
+          locateNode(payload, address)
+        }
       }
     }
   })
@@ -440,6 +445,12 @@ export const spliceArrayState = (
             address: newIdentifier,
             oldAddress: identifier,
             payload: field,
+            oldPayload: fields[newIdentifier]
+              ? {
+                  address: fields[newIdentifier].address,
+                  path: fields[newIdentifier].path,
+                }
+              : undefined,
           })
           if (isNeedCleanupNode(identifier)) {
             fieldPatches.push({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -111,6 +111,7 @@ export interface INodePatch<T> {
   address: string
   oldAddress?: string
   payload?: T
+  oldPayload?: Partial<T>
 }
 
 export interface IHeartProps<Context> {

--- a/packages/react/docs/api/components/ArrayField.md
+++ b/packages/react/docs/api/components/ArrayField.md
@@ -40,7 +40,10 @@ const ArrayComponent = observer(() => {
     <>
       <div>
         {field.value?.map((item, index) => (
-          <div key={index} style={{ display: 'flex-block', marginBottom: 10 }}>
+          <div
+            key={field.getIndexKey(index)}
+            style={{ display: 'flex-block', marginBottom: 10 }}
+          >
             <Space>
               <Field name={index} component={[Input]} />
               <Button
@@ -105,7 +108,7 @@ export default () => (
             <div>
               {field.value?.map((item, index) => (
                 <div
-                  key={index}
+                  key={field.getIndexKey(index)}
                   style={{ display: 'flex-block', marginBottom: 10 }}
                 >
                   <Space>

--- a/packages/react/docs/api/components/ArrayField.zh-CN.md
+++ b/packages/react/docs/api/components/ArrayField.zh-CN.md
@@ -40,7 +40,10 @@ const ArrayComponent = observer(() => {
     <>
       <div>
         {field.value?.map((item, index) => (
-          <div key={index} style={{ display: 'flex-block', marginBottom: 10 }}>
+          <div
+            key={field.getIndexKey(index)}
+            style={{ display: 'flex-block', marginBottom: 10 }}
+          >
             <Space>
               <Field name={index} component={[Input]} />
               <Button
@@ -105,7 +108,7 @@ export default () => (
             <div>
               {field.value?.map((item, index) => (
                 <div
-                  key={index}
+                  key={field.getIndexKey(index)}
                   style={{ display: 'flex-block', marginBottom: 10 }}
                 >
                   <Space>

--- a/packages/react/docs/api/components/RecursionField.md
+++ b/packages/react/docs/api/components/RecursionField.md
@@ -97,7 +97,7 @@ const ArrayItems = observer((props) => {
     <div>
       {props.value?.map((item, index) => {
         return (
-          <div key={index} style={{ marginBottom: 10 }}>
+          <div key={field.getIndexKey(index)} style={{ marginBottom: 10 }}>
             <Space>
               <RecursionField schema={schema.items} name={index} />
               <Button

--- a/packages/react/docs/api/components/RecursionField.zh-CN.md
+++ b/packages/react/docs/api/components/RecursionField.zh-CN.md
@@ -97,7 +97,7 @@ const ArrayItems = observer((props) => {
     <div>
       {props.value?.map((item, index) => {
         return (
-          <div key={index} style={{ marginBottom: 10 }}>
+          <div key={field.getIndexKey(index)} style={{ marginBottom: 10 }}>
             <Space>
               <RecursionField schema={schema.items} name={index} />
               <Button

--- a/packages/reactive/src/__tests__/autorun.spec.ts
+++ b/packages/reactive/src/__tests__/autorun.spec.ts
@@ -757,3 +757,207 @@ test('avoid unnecessary reaction', () => {
 
   expect(fn1).toBeCalledTimes(1)
 })
+
+test('avoid missing reaction', () => {
+  const obs = observable<any>({
+    res: 0,
+  })
+
+  const fn1 = jest.fn()
+  const fn2 = jest.fn()
+
+  let value
+  autorun(() => {
+    fn1()
+    value = obs.res
+  })
+
+  autorun(() => {
+    fn2()
+    obs.res
+    if (obs.res !== 0) obs.res = obs.res + 1
+  })
+
+  expect(value).toBe(0)
+
+  obs.res = 1
+
+  expect(value).toBe(2)
+
+  expect(fn1).toBeCalledTimes(3)
+  expect(fn2).toBeCalledTimes(2)
+})
+
+test('avoid reaction twice', () => {
+  const obs = observable<any>({
+    res: 0,
+  })
+
+  const fn1 = jest.fn()
+  const fn2 = jest.fn()
+
+  let value
+  autorun(() => {
+    fn1()
+    obs.res
+    if (obs.res !== 0) obs.res = obs.res + 1
+  })
+
+  autorun(() => {
+    fn2()
+    value = obs.res
+  })
+
+  expect(value).toBe(0)
+
+  obs.res = 1
+
+  expect(value).toBe(2)
+  expect(fn1).toBeCalledTimes(2)
+  expect(fn2).toBeCalledTimes(2)
+})
+
+test('computed reaction', () => {
+  const obs = observable<any>({
+    aa: 1,
+    bb: 1,
+  })
+
+  const computed = observable.computed(() => {
+    return obs.aa + obs.bb
+  })
+
+  autorun(() => {
+    if (obs.bb === 3) {
+      obs.aa = 3
+    }
+  })
+
+  batch(() => {
+    obs.aa = 2 // 会触发 computed 发生变化
+
+    obs.bb = 3
+  })
+
+  expect(computed.value).toBe(6)
+})
+
+test('accurate boundary', () => {
+  const obs = observable<any>({
+    a: '',
+    b: '',
+    c: '',
+  })
+
+  autorun(() => {
+    obs.c = obs.a + obs.b
+  })
+
+  autorun(() => {
+    obs.b = obs.a
+  })
+
+  obs.a = 'a'
+  expect(obs.a).toBe('a')
+  expect(obs.b).toBe('a')
+  expect(obs.c).toBe('aa')
+})
+
+test('multiple source update', () => {
+  const obs = observable<any>({})
+
+  const fn1 = jest.fn()
+  const fn2 = jest.fn()
+
+  autorun(() => {
+    const A = obs.A
+    const B = obs.B
+    if (A !== undefined && B !== undefined) {
+      obs.C = A / B
+      fn1()
+    }
+  })
+
+  autorun(() => {
+    const C = obs.C
+    const B = obs.B
+    if (C !== undefined && B !== undefined) {
+      obs.D = C * B
+      fn2()
+    }
+  })
+
+  obs.A = 1
+  obs.B = 2
+
+  expect(fn1).toBeCalledTimes(1)
+  expect(fn2).toBeCalledTimes(1)
+})
+
+test('same source in nest update', () => {
+  const obs = observable<any>({})
+
+  const fn1 = jest.fn()
+
+  autorun(() => {
+    const B = obs.B
+    obs.B = 'B'
+    fn1()
+    return B
+  })
+
+  obs.B = 'B2'
+
+  expect(fn1).toBeCalledTimes(2)
+})
+
+test('batch execute autorun cause by deep indirect dependency', () => {
+  const obs: any = observable({ aa: 1, bb: 1, cc: 1 })
+  const fn = jest.fn()
+  const fn2 = jest.fn()
+  const fn3 = jest.fn()
+
+  autorun(() => fn((obs.aa = obs.bb + obs.cc)))
+  autorun(() => fn2((obs.bb = obs.aa + obs.cc)))
+  autorun(() => fn3((obs.cc = obs.aa + obs.bb)))
+
+  // 嵌套写法重复调用没意义，只需要确保最新被触发的 reaction 执行，已过时的 reaction 可以忽略
+  // 比如 fn3 执行，触发 fn 和 fn2，fn 执行又触发 fn2，之前触发的 fn2 是过时的，忽略处理，fn2 只执行一次
+  expect(fn).toBeCalledTimes(3)
+  expect(fn2).toBeCalledTimes(2)
+  expect(fn3).toBeCalledTimes(1)
+
+  fn.mockClear()
+  fn2.mockClear()
+  fn3.mockClear()
+
+  batch(() => {
+    obs.aa = 100
+    obs.bb = 100
+    obs.cc = 100
+  })
+
+  expect(fn).toBeCalledTimes(1)
+  expect(fn2).toBeCalledTimes(1)
+  expect(fn3).toBeCalledTimes(1)
+})
+
+test('multiple update should trigger only one', () => {
+  const obs = observable({ aa: 1, bb: 1 })
+
+  autorun(() => {
+    obs.aa = obs.bb + 1
+    obs.bb = obs.aa + 1
+  })
+
+  expect(obs.aa).toBe(2)
+  expect(obs.bb).toBe(3)
+
+  autorun(() => {
+    obs.aa = obs.bb + 1
+    obs.bb = obs.aa + 1
+  })
+
+  expect(obs.aa).toBe(6)
+  expect(obs.bb).toBe(7)
+})

--- a/packages/reactive/src/__tests__/autorun.spec.ts
+++ b/packages/reactive/src/__tests__/autorun.spec.ts
@@ -741,3 +741,19 @@ test('reaction recollect dependencies', () => {
   expect(fn2).toBeCalledTimes(2)
   expect(trigger2).toBeCalledTimes(2)
 })
+
+test('avoid unnecessary reaction', () => {
+  const obs = observable<any>({
+    aa: { v: 1 },
+  })
+  const fn1 = jest.fn()
+
+  reaction(() => {
+    fn1()
+    return obs.aa.v
+  })
+
+  obs.aa = obs.aa
+
+  expect(fn1).toBeCalledTimes(1)
+})

--- a/packages/reactive/src/__tests__/tracker.spec.ts
+++ b/packages/reactive/src/__tests__/tracker.spec.ts
@@ -89,5 +89,5 @@ test('shared scheduler with multi tracker(mock react strict mode)', () => {
   obs.value = 123
 
   expect(scheduler1).toBeCalledTimes(1)
-  expect(scheduler2).toBeCalledTimes(0)
+  expect(scheduler2).toBeCalledTimes(1)
 })

--- a/packages/reactive/src/annotations/computed.ts
+++ b/packages/reactive/src/annotations/computed.ts
@@ -1,4 +1,9 @@
-import { ObModelSymbol, ReactionStack } from '../environment'
+import {
+  ObModelSymbol,
+  PendingComputedReactions,
+  PendingScopeComputedReactions,
+  ReactionStack,
+} from '../environment'
 import { createAnnotation } from '../internals'
 import { buildDataTree } from '../tree'
 import { isFn } from '../checkers'
@@ -13,6 +18,7 @@ import {
   releaseBindingReactions,
   getReactionsFromTargetKey,
 } from '../reaction'
+import { Reaction } from '../types'
 
 interface IValue<T = any> {
   value?: T
@@ -68,6 +74,13 @@ function getPrototypeDescriptor(
   return {}
 }
 
+const isAllComputedDeps = (reaction: Reaction) => {
+  if (!reaction._isComputed) return false
+  const deps = getReactionsFromTargetKey(reaction._context, reaction._property)
+  if (!deps.length) return true
+  return deps.every((dep) => isAllComputedDeps(dep))
+}
+
 export const computed: IComputed = createAnnotation(
   ({ target, key, value }) => {
     const store: IValue = {}
@@ -95,9 +108,6 @@ export const computed: IComputed = createAnnotation(
 
     reaction._name = 'ComputedReaction'
     reaction._scheduler = () => {
-      if (!reaction._dirty_scheduler) return
-      reaction._dirty_scheduler = false
-
       if (!reaction._dirty) {
         runReactionsFromTargetKey({
           target: context,
@@ -112,7 +122,7 @@ export const computed: IComputed = createAnnotation(
 
       if (!deps.length) return
 
-      if (deps.every((dep) => dep._isComputed)) {
+      if (deps.every((dep) => isAllComputedDeps(dep))) {
         // all deps are computed reactions, so should dirty the upstream computed reactions
         runReactionsFromTargetKey({
           target: context,
@@ -140,8 +150,6 @@ export const computed: IComputed = createAnnotation(
     reaction._isComputed = true
     // is need to re calculate
     reaction._dirty = true
-    // is need to schedule to notice upstream reactions
-    reaction._dirty_scheduler = true
     reaction._context = context
     reaction._property = property
 
@@ -157,9 +165,10 @@ export const computed: IComputed = createAnnotation(
           reaction()
           reaction._dirty = false
           const newValue = store.value
-          if (newValue === currentValue) {
-            // no need to schedule
-            reaction._dirty_scheduler = false
+          if (newValue !== currentValue) {
+            // if the value is changed, it should be scheduled
+            PendingComputedReactions.update(reaction)
+            PendingScopeComputedReactions.update(reaction)
           }
         }
         bindTargetKeyWithCurrentReaction({

--- a/packages/reactive/src/annotations/computed.ts
+++ b/packages/reactive/src/annotations/computed.ts
@@ -11,6 +11,7 @@ import {
   batchStart,
   batchEnd,
   releaseBindingReactions,
+  getReactionsFromTargetKey,
 } from '../reaction'
 
 interface IValue<T = any> {
@@ -91,18 +92,56 @@ export const computed: IComputed = createAnnotation(
         }
       }
     }
+
     reaction._name = 'ComputedReaction'
     reaction._scheduler = () => {
-      reaction._dirty = true
-      runReactionsFromTargetKey({
-        target: context,
-        key: property,
-        value: store.value,
-        type: 'set',
-      })
+      if (!reaction._dirty_scheduler) return
+      reaction._dirty_scheduler = false
+
+      if (!reaction._dirty) {
+        runReactionsFromTargetKey({
+          target: context,
+          key: property,
+          value: store.value,
+          type: 'set',
+        })
+        return
+      }
+
+      const deps = getReactionsFromTargetKey(context, property)
+
+      if (!deps.length) return
+
+      if (deps.every((dep) => dep._isComputed)) {
+        // all deps are computed reactions, so should dirty the upstream computed reactions
+        runReactionsFromTargetKey({
+          target: context,
+          key: property,
+          value: store.value,
+          type: 'set',
+        })
+        return
+      }
+
+      const currentValue = store.value
+      reaction()
+      reaction._dirty = false
+      const newValue = store.value
+      if (newValue !== currentValue) {
+        runReactionsFromTargetKey({
+          target: context,
+          key: property,
+          value: store.value,
+          type: 'set',
+        })
+      }
     }
+
     reaction._isComputed = true
+    // is need to re calculate
     reaction._dirty = true
+    // is need to schedule to notice upstream reactions
+    reaction._dirty_scheduler = true
     reaction._context = context
     reaction._property = property
 
@@ -113,18 +152,25 @@ export const computed: IComputed = createAnnotation(
       if (!isUntracking()) {
         //如果允许untracked过程中收集依赖，那么永远不会存在绑定，因为_dirty已经设置为false
         if (reaction._dirty) {
+          // if the value is used in batch function, it will directly execute and set dirty to false
+          const currentValue = store.value
           reaction()
           reaction._dirty = false
+          const newValue = store.value
+          if (newValue === currentValue) {
+            // no need to schedule
+            reaction._dirty_scheduler = false
+          }
         }
-      } else {
-        compute()
+        bindTargetKeyWithCurrentReaction({
+          target: context,
+          key: property,
+          type: 'get',
+        })
+        return store.value
       }
-      bindTargetKeyWithCurrentReaction({
-        target: context,
-        key: property,
-        type: 'get',
-      })
-      return store.value
+
+      return descriptor.get?.call(context)
     }
 
     function set(value: any) {

--- a/packages/reactive/src/array.ts
+++ b/packages/reactive/src/array.ts
@@ -49,12 +49,15 @@ export class ArraySet<T> {
 
   batchDelete(callback: (value: T) => void) {
     if (this.value.length === 0) return
-    this.forEachIndex = 0
-    for (; this.forEachIndex < this.value.length; this.forEachIndex++) {
-      const value = this.value[this.forEachIndex]
-      this.value.splice(this.forEachIndex, 1)
-      this.forEachIndex--
-      callback(value)
+
+    const batchList = this.value.splice(0, this.value.length)
+
+    for (let i = 0; i < batchList.length; i++) {
+      callback(batchList[i])
+    }
+
+    if (this.value.length > 0) {
+      this.batchDelete(callback)
     }
   }
 

--- a/packages/reactive/src/environment.ts
+++ b/packages/reactive/src/environment.ts
@@ -1,5 +1,6 @@
 import { ObservableListener, Reaction, ReactionsMap } from './types'
 import { ArraySet } from './array'
+import { ReactionsArraySet } from './reactions-array-set'
 import { DataNode } from './tree'
 
 export const ProxyRaw = new WeakMap()
@@ -13,10 +14,10 @@ export const BatchCount = { value: 0 }
 export const UntrackCount = { value: 0 }
 export const BatchScope = { value: false }
 export const DependencyCollected = { value: false }
-export const PendingReactions = new ArraySet<Reaction>()
-export const PendingScopeReactions = new ArraySet<Reaction>()
-export const PendingComputedReactions = new ArraySet<Reaction>()
-export const PendingScopeComputedReactions = new ArraySet<Reaction>()
+export const PendingReactions = new ReactionsArraySet<Reaction>()
+export const PendingScopeReactions = new ReactionsArraySet<Reaction>()
+export const PendingComputedReactions = new ReactionsArraySet<Reaction>()
+export const PendingScopeComputedReactions = new ReactionsArraySet<Reaction>()
 export const BatchEndpoints = new ArraySet<() => void>()
 export const ObserverListeners = new ArraySet<ObservableListener>()
 export const MakeObModelSymbol = Symbol('MakeObModelSymbol')

--- a/packages/reactive/src/environment.ts
+++ b/packages/reactive/src/environment.ts
@@ -12,6 +12,7 @@ export const RawReactionsMap = new WeakMap<object, ReactionsMap>()
 export const ReactionStack: Reaction[] = []
 export const BatchCount = { value: 0 }
 export const UntrackCount = { value: 0 }
+export const BatchIdRef = { current: 1 }
 export const BatchScope = { value: false }
 export const DependencyCollected = { value: false }
 export const PendingReactions = new ReactionsArraySet<Reaction>()

--- a/packages/reactive/src/environment.ts
+++ b/packages/reactive/src/environment.ts
@@ -15,6 +15,8 @@ export const BatchScope = { value: false }
 export const DependencyCollected = { value: false }
 export const PendingReactions = new ArraySet<Reaction>()
 export const PendingScopeReactions = new ArraySet<Reaction>()
+export const PendingComputedReactions = new ArraySet<Reaction>()
+export const PendingScopeComputedReactions = new ArraySet<Reaction>()
 export const BatchEndpoints = new ArraySet<() => void>()
 export const ObserverListeners = new ArraySet<ObservableListener>()
 export const MakeObModelSymbol = Symbol('MakeObModelSymbol')

--- a/packages/reactive/src/handlers.ts
+++ b/packages/reactive/src/handlers.ts
@@ -207,7 +207,12 @@ export const baseHandlers: ProxyHandler<any> = {
     }
     const hadKey = hasOwnProperty.call(target, key)
     const newValue = createObservable(target, key, value)
-    const oldValue = target[key]
+
+    // If the old value has already generated an observable result,
+    // directly use observableResult compapre to value to avoid unnecessary reactions
+    const observableResult = RawProxy.get(target[key])
+    const oldValue = observableResult ? observableResult : target[key]
+
     target[key] = newValue // use Reflect.set is too slow
     if (!hadKey) {
       runReactionsFromTargetKey({

--- a/packages/reactive/src/reaction.ts
+++ b/packages/reactive/src/reaction.ts
@@ -15,6 +15,7 @@ import {
   ObserverListeners,
   PendingComputedReactions,
   PendingScopeComputedReactions,
+  BatchIdRef,
 } from './environment'
 
 const ITERATION_KEY = Symbol('iteration key')
@@ -224,13 +225,7 @@ export const batchScopeEnd = () => {
   })
 
   BatchScope.value = false
-  PendingScopeReactions.batchDelete((reaction) => {
-    if (isFn(reaction._scheduler)) {
-      reaction._scheduler(reaction)
-    } else {
-      reaction()
-    }
-  })
+  executePendingScopeReactions()
   UntrackCount.value = prevUntrackCount
 }
 
@@ -257,11 +252,29 @@ export const executePendingComputedReactions = () => {
 }
 
 export const executePendingReactions = () => {
+  const batchId = BatchIdRef.current++
   PendingReactions.batchDelete((reaction) => {
-    if (isFn(reaction._scheduler)) {
-      reaction._scheduler(reaction)
-    } else {
-      reaction()
+    if (batchId > (reaction._batchId || 0)) {
+      reaction._batchId = batchId
+      if (isFn(reaction._scheduler)) {
+        reaction._scheduler(reaction)
+      } else {
+        reaction()
+      }
+    }
+  })
+}
+
+export const executePendingScopeReactions = () => {
+  const batchId = BatchIdRef.current++
+  PendingScopeReactions.batchDelete((reaction) => {
+    if (batchId > (reaction._batchId || 0)) {
+      reaction._batchId = batchId
+      if (isFn(reaction._scheduler)) {
+        reaction._scheduler(reaction)
+      } else {
+        reaction()
+      }
     }
   })
 }

--- a/packages/reactive/src/reaction.ts
+++ b/packages/reactive/src/reaction.ts
@@ -12,6 +12,8 @@ import {
   UntrackCount,
   BatchScope,
   ObserverListeners,
+  PendingComputedReactions,
+  PendingScopeComputedReactions,
 } from './environment'
 
 const ITERATION_KEY = Symbol('iteration key')
@@ -52,7 +54,7 @@ const addReactionsMapToReaction = (
   return bindSet
 }
 
-const getReactionsFromTargetKey = (target: any, key: PropertyKey) => {
+export const getReactionsFromTargetKey = (target: any, key: PropertyKey) => {
   const reactionsMap = RawReactionsMap.get(target)
   const reactions = []
   if (reactionsMap) {
@@ -75,7 +77,15 @@ const runReactions = (target: any, key: PropertyKey) => {
   for (let i = 0, len = reactions.length; i < len; i++) {
     const reaction = reactions[i]
     if (reaction._isComputed) {
-      reaction._scheduler(reaction)
+      reaction._dirty = true
+      reaction._dirty_scheduler = true
+      if (isScopeBatching()) {
+        PendingScopeComputedReactions.add(reaction)
+      } else if (isBatching()) {
+        PendingComputedReactions.add(reaction)
+      } else {
+        reaction._scheduler(reaction)
+      }
     } else if (isScopeBatching()) {
       PendingScopeReactions.add(reaction)
     } else if (isBatching()) {
@@ -182,13 +192,18 @@ export const batchStart = () => {
 }
 
 export const batchEnd = () => {
-  BatchCount.value--
-  if (BatchCount.value === 0) {
+  if (BatchCount.value === 1) {
     const prevUntrackCount = UntrackCount.value
     UntrackCount.value = 0
+    executePendingComputedReactions()
+
+    BatchCount.value--
+
     executePendingReactions()
     executeBatchEndpoints()
     UntrackCount.value = prevUntrackCount
+  } else {
+    BatchCount.value--
   }
 }
 
@@ -198,8 +213,15 @@ export const batchScopeStart = () => {
 
 export const batchScopeEnd = () => {
   const prevUntrackCount = UntrackCount.value
-  BatchScope.value = false
   UntrackCount.value = 0
+
+  PendingScopeComputedReactions.batchDelete((reaction) => {
+    if (isFn(reaction._scheduler)) {
+      reaction._scheduler(reaction)
+    }
+  })
+
+  BatchScope.value = false
   PendingScopeReactions.batchDelete((reaction) => {
     if (isFn(reaction._scheduler)) {
       reaction._scheduler(reaction)
@@ -223,6 +245,14 @@ export const isBatching = () => BatchCount.value > 0
 export const isScopeBatching = () => BatchScope.value
 
 export const isUntracking = () => UntrackCount.value > 0
+
+export const executePendingComputedReactions = () => {
+  PendingComputedReactions.batchDelete((reaction) => {
+    if (isFn(reaction._scheduler)) {
+      reaction._scheduler(reaction)
+    }
+  })
+}
 
 export const executePendingReactions = () => {
   PendingReactions.batchDelete((reaction) => {

--- a/packages/reactive/src/reaction.ts
+++ b/packages/reactive/src/reaction.ts
@@ -1,5 +1,6 @@
 import { isFn } from './checkers'
 import { ArraySet } from './array'
+import { ReactionsArraySet } from './reactions-array-set'
 import { IOperation, ReactionsMap, Reaction, PropertyKey } from './types'
 import {
   ReactionStack,
@@ -28,28 +29,29 @@ const addRawReactionsMap = (
     const reactions = reactionsMap.get(key)
     if (reactions) {
       reactions.add(reaction)
+      return reactions
     } else {
-      reactionsMap.set(key, new ArraySet([reaction]))
+      reactionsMap.set(key, new ReactionsArraySet([reaction]))
+      return reactionsMap.get(key)
     }
-    return reactionsMap
   } else {
     const reactionsMap: ReactionsMap = new Map([
-      [key, new ArraySet([reaction])],
+      [key, new ReactionsArraySet([reaction])],
     ])
     RawReactionsMap.set(target, reactionsMap)
-    return reactionsMap
+    return reactionsMap.get(key)
   }
 }
 
-const addReactionsMapToReaction = (
+const addReactionsSetToReaction = (
   reaction: Reaction,
-  reactionsMap: ReactionsMap
+  reactionsSet: ReactionsArraySet<Reaction>
 ) => {
   const bindSet = reaction._reactionsSet
   if (bindSet) {
-    bindSet.add(reactionsMap)
+    bindSet.add(reactionsSet)
   } else {
-    reaction._reactionsSet = new ArraySet([reactionsMap])
+    reaction._reactionsSet = new ArraySet([reactionsSet])
   }
   return bindSet
 }
@@ -61,9 +63,7 @@ export const getReactionsFromTargetKey = (target: any, key: PropertyKey) => {
     const map = reactionsMap.get(key)
     if (map) {
       map.forEach((reaction) => {
-        if (reactions.indexOf(reaction) === -1) {
-          reactions.push(reaction)
-        }
+        reactions.push(reaction)
       })
     }
   }
@@ -78,7 +78,6 @@ const runReactions = (target: any, key: PropertyKey) => {
     const reaction = reactions[i]
     if (reaction._isComputed) {
       reaction._dirty = true
-      reaction._dirty_scheduler = true
       if (isScopeBatching()) {
         PendingScopeComputedReactions.add(reaction)
       } else if (isBatching()) {
@@ -117,7 +116,7 @@ export const bindTargetKeyWithCurrentReaction = (operation: IOperation) => {
   if (isUntracking()) return
   if (current) {
     DependencyCollected.value = true
-    addReactionsMapToReaction(current, addRawReactionsMap(target, key, current))
+    addReactionsSetToReaction(current, addRawReactionsMap(target, key, current))
   }
 }
 
@@ -158,13 +157,11 @@ export const hasRunningReaction = () => {
 }
 
 export const releaseBindingReactions = (reaction: Reaction) => {
-  reaction._reactionsSet?.forEach((reactionsMap) => {
-    reactionsMap.forEach((reactions) => {
-      reactions.delete(reaction)
-    })
-  })
-  PendingReactions.delete(reaction)
-  PendingScopeReactions.delete(reaction)
+  // delete outdated reaction by _reactionId
+  if (typeof reaction._reactionId !== 'number') {
+    reaction._reactionId = 0
+  } else reaction._reactionId++
+
   delete reaction._reactionsSet
 }
 
@@ -183,6 +180,11 @@ export const suspendComputedReactions = (current: Reaction) => {
 
 export const disposeBindingReactions = (reaction: Reaction) => {
   reaction._disposed = true
+
+  reaction._reactionsSet?.forEach((reactionsSet) => {
+    reactionsSet.delete(reaction)
+  })
+
   releaseBindingReactions(reaction)
   suspendComputedReactions(reaction)
 }

--- a/packages/reactive/src/reactions-array-set.ts
+++ b/packages/reactive/src/reactions-array-set.ts
@@ -1,0 +1,73 @@
+import { Reaction } from './types'
+
+/**
+ * work like arrayset but delete outdated reaction by _reactionId
+ */
+export class ReactionsArraySet<T extends Reaction> {
+  valueSet: Set<T>
+  reactionIdMap: Map<T, number>
+  forEachIndex = 0
+  constructor(value: T[] = []) {
+    this.valueSet = new Set()
+    this.reactionIdMap = new Map()
+    value.forEach((item) => {
+      this.add(item)
+    })
+  }
+
+  add(item: T) {
+    if (!this.has(item)) {
+      this.valueSet.add(item)
+      this.reactionIdMap.set(item, item._reactionId || 0)
+    } else {
+      this.reactionIdMap.set(item, item._reactionId || 0)
+    }
+  }
+
+  has(item: T) {
+    return this.valueSet.has(item)
+  }
+
+  update(item: T) {
+    if (this.valueSet.has(item)) {
+      this.reactionIdMap.set(item, item._reactionId || 0)
+    }
+  }
+
+  delete(item: T) {
+    const size = this.valueSet.size
+    if (size === 0) return
+    this.valueSet.delete(item)
+    this.reactionIdMap.delete(item)
+  }
+
+  forEach(callback: (value: T) => void) {
+    if (this.valueSet.size === 0) return
+    for (const item of this.valueSet) {
+      const reactionId = this.reactionIdMap.get(item)
+      if (reactionId === item._reactionId) {
+        callback(item)
+      } else {
+        this.delete(item)
+      }
+    }
+  }
+
+  batchDelete(callback: (value: T) => void) {
+    if (this.valueSet.size === 0) return
+
+    for (const item of this.valueSet) {
+      const reactionId = this.reactionIdMap.get(item)
+      if (reactionId === item._reactionId) {
+        callback(item)
+      }
+    }
+
+    this.clear()
+  }
+
+  clear() {
+    this.valueSet.clear()
+    this.reactionIdMap.clear()
+  }
+}

--- a/packages/reactive/src/reactions-array-set.ts
+++ b/packages/reactive/src/reactions-array-set.ts
@@ -56,14 +56,24 @@ export class ReactionsArraySet<T extends Reaction> {
   batchDelete(callback: (value: T) => void) {
     if (this.valueSet.size === 0) return
 
+    const list = []
+
     for (const item of this.valueSet) {
       const reactionId = this.reactionIdMap.get(item)
       if (reactionId === item._reactionId) {
-        callback(item)
+        list.push(item)
       }
     }
 
     this.clear()
+
+    for (let i = 0; i < list.length; i++) {
+      callback(list[i])
+    }
+
+    if (this.valueSet.size > 0) {
+      this.batchDelete(callback)
+    }
   }
 
   clear() {

--- a/packages/reactive/src/types.ts
+++ b/packages/reactive/src/types.ts
@@ -72,6 +72,7 @@ export type Reaction = ((...args: any[]) => any) & {
   _computesSet?: ArraySet<Reaction>
   _reactionsSet?: ArraySet<ReactionsArraySet<Reaction>>
   _reactionId?: number
+  _batchId?: number
   _scheduler?: (reaction: Reaction) => void
   _memos?: {
     queue: IMemoQueueItem[]

--- a/packages/reactive/src/types.ts
+++ b/packages/reactive/src/types.ts
@@ -1,4 +1,5 @@
 import { ArraySet } from './array'
+import { ReactionsArraySet } from './reactions-array-set'
 
 export * from './tree'
 
@@ -69,7 +70,8 @@ export type Reaction = ((...args: any[]) => any) & {
   _disposed?: boolean
   _property?: PropertyKey
   _computesSet?: ArraySet<Reaction>
-  _reactionsSet?: ArraySet<ReactionsMap>
+  _reactionsSet?: ArraySet<ReactionsArraySet<Reaction>>
+  _reactionId?: number
   _scheduler?: (reaction: Reaction) => void
   _memos?: {
     queue: IMemoQueueItem[]
@@ -81,7 +83,7 @@ export type Reaction = ((...args: any[]) => any) & {
   }
 }
 
-export type ReactionsMap = Map<PropertyKey, ArraySet<Reaction>>
+export type ReactionsMap = Map<PropertyKey, ReactionsArraySet<Reaction>>
 
 export interface IReactionOptions<T> {
   name?: string

--- a/packages/vue/docs/demos/api/components/array-field.vue
+++ b/packages/vue/docs/demos/api/components/array-field.vue
@@ -4,7 +4,7 @@
       <template #default="{ field }">
         <div
           v-for="(item, index) in field.value || []"
-          :key="`${item.id}-${index}`"
+          :key="field.getIndexKey(index)"
           :style="{ marginBottom: '10px' }"
         >
           <Space>


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [✅] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [ ✅] Fork the repo and create your branch from `master` or `formily_next`.
- [ ✅] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [✅ ] Ensure the test suite passes (`npm test`).
- [ ✅] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

可以查看最新的单个 commit 来看当前 pr 更改内容。

避免因链式响应，比如 fn1 收集依赖 A，fn2 收集并更新依赖 A，在 A 改变时，触发 fn1 和 fn2，其中 fn2 再次触发 fn1 时，因为 fn1 的防死循环机制(_boundary) ，导致 fn1 不能被再次触发获取到最新的依赖 A。

链式响应应该确保本身不会被再次执行，同时只需要触发最新的一次响应。
比如是先 fn1 再 fn2 的顺序，应该先执行 fn1 再执行 fn2 再执行 fn1 （一定会执行最新的一次）
如果两个函数调换顺序，则应该只需要执行 fn2 fn1，fn1 只会被执行一次（一定会执行最新的一次）

具体的响应策略和之前的 pr 不太一致，但想要解决的问题是一致的。

#4255


