### PR TITLE
fix(react): fix import error doesn't catch

### DIFF
--- a/packages/react/src/shared/render.ts
+++ b/packages/react/src/shared/render.ts
@@ -24,7 +24,7 @@ const loadCreatePortal = () => {
       // @ts-ignore
       import('react-dom')
         .then((module) => (env.createPortal ??= module?.createPortal))
-        .catch()
+        .catch(() => {})
     } catch {}
   }
 }


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [ ] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch) said

> This means that passing undefined still causes the returned promise to be rejected, and you have to pass a function to prevent the final promise from being rejected.

in some environment without `react-dom`, this module will throw a error.
