### PR TITLE
fix(react): fix some render issue in non web browser environment

### DIFF
--- a/packages/react/src/shared/render.ts
+++ b/packages/react/src/shared/render.ts
@@ -6,10 +6,31 @@ interface Env {
   createPortal?: (children: ReactNode, container: Element) => ReactPortal
 }
 
+const createPortalDOM = () => {
+  try {
+    // env.portalDOM work with env.createPortal
+    if (!env.createPortal) {
+      return
+    }
+
+    // environment not support div element
+    // @ts-ignore
+    if (typeof globalThisPolyfill?.HTMLDivElement !== 'function') {
+      return
+    }
+
+    env.portalDOM ??= globalThisPolyfill?.document?.createElement?.('div')
+  } catch (error) {
+    // do nothing
+  }
+}
+
 const env: Env = {
-  portalDOM: globalThisPolyfill?.document?.createElement?.('div'),
+  portalDOM: undefined,
   createPortal: globalThisPolyfill?.['ReactDOM']?.createPortal,
 }
+
+createPortalDOM()
 
 /* istanbul ignore next */
 const loadCreatePortal = () => {
@@ -17,25 +38,39 @@ const loadCreatePortal = () => {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       env.createPortal ??= require('react-dom')?.createPortal
+      createPortalDOM()
     } catch {}
   }
   if (!env.createPortal) {
     try {
       // @ts-ignore
       import('react-dom')
-        .then((module) => (env.createPortal ??= module?.createPortal))
+        .then((module) => {
+          env.createPortal ??= module?.createPortal
+          createPortalDOM()
+        })
         .catch()
     } catch {}
   }
 }
 
+// test template element is supported in current environment
+const supportsTemplate =
+  // @ts-ignore
+  typeof globalThisPolyfill?.HTMLTemplateElement === 'function' &&
+  // @ts-ignore
+  'content' in globalThisPolyfill?.HTMLTemplateElement?.prototype
+
 export const render = (element: React.ReactElement) => {
-  if (globalThisPolyfill.navigator?.product === 'ReactNative') return null
+  if (globalThisPolyfill?.navigator?.product === 'ReactNative') return null
+
   if (env.portalDOM && env.createPortal) {
     return env.createPortal(element, env.portalDOM)
-  } else {
+  } else if (supportsTemplate) {
     return React.createElement('template', {}, element)
   }
+
+  return null
 }
 
 loadCreatePortal()


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [ ] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

1. in `formily-react`, `render.ts` will try to create a `div` element when load module, this action may throw a error in some non web browser. But in `render` function, `env.portalDOM` just work with `env.createPortal`, so I try to create `env.portalDOM` lazy when `env.createPortal` not `undefined` (or loaded). I also add a environment test before create a `div` element.
2. also, `template` not support in non web browser environment, and  `globalThisPolyfill?.navigator?.product === 'ReactNative'` just support RN, then I try to test `template` element support in current environment directly.
