### PR TITLE
fix(a11y): add alt text to images for better accessibility

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,10 @@ export default () => (
     scale={1.2}
   >
     <a href="//designable-antd.formilyjs.org" target="_blank" rel="noreferrer">
-      <img src="//img.alicdn.com/imgextra/i2/O1CN01eI9FLz22tZek2jv7E_!!6000000007178-2-tps-3683-2272.png" />
+      <img
+        src="//img.alicdn.com/imgextra/i2/O1CN01eI9FLz22tZek2jv7E_!!6000000007178-2-tps-3683-2272.png"
+        alt="Formily Form Builder"
+      />
     </a>
   </Section>
 )
@@ -83,7 +86,10 @@ export default () => (
     titleStyle={{ paddingBottom: 100, fontWeight: 'bold' }}
   >
     <a href="//core.formilyjs.org" target="_blank" rel="noreferrer">
-      <img src="//img.alicdn.com/imgextra/i4/O1CN019qbf1b1ChnTfT9x3X_!!6000000000113-55-tps-1939-1199.svg" />
+      <img
+        src="//img.alicdn.com/imgextra/i4/O1CN019qbf1b1ChnTfT9x3X_!!6000000000113-55-tps-1939-1199.svg"
+        alt="Formily Core"
+      />
     </a>
   </Section>
 )
@@ -125,7 +131,10 @@ export default () => (
     titleStyle={{ paddingBottom: 20, fontWeight: 'bold' }}
   >
     <QrCodeGroup>
-      <QrCode link="//img.alicdn.com/imgextra/i1/O1CN011zlc5b1uu1BDUpNg1_!!6000000006096-2-tps-978-1380.png" />
+      <QrCode
+        link="//img.alicdn.com/imgextra/i1/O1CN011zlc5b1uu1BDUpNg1_!!6000000006096-2-tps-978-1380.png"
+        alt="Formily Community QR Code"
+      />
     </QrCodeGroup>
   </Section>
 )

--- a/docs/index.zh-CN.md
+++ b/docs/index.zh-CN.md
@@ -62,7 +62,10 @@ export default () => (
     scale={1.2}
   >
     <a href="//designable-antd.formilyjs.org" target="_blank" rel="noreferrer">
-      <img src="//img.alicdn.com/imgextra/i2/O1CN01eI9FLz22tZek2jv7E_!!6000000007178-2-tps-3683-2272.png" />
+      <img
+        src="//img.alicdn.com/imgextra/i2/O1CN01eI9FLz22tZek2jv7E_!!6000000007178-2-tps-3683-2272.png"
+        alt="Formily 表单设计器"
+      />
     </a>
   </Section>
 )
@@ -83,7 +86,10 @@ export default () => (
     titleStyle={{ paddingBottom: 100 }}
   >
     <a href="//core.formilyjs.org" target="_blank" rel="noreferrer">
-      <img src="//img.alicdn.com/imgextra/i3/O1CN01iEwHrP1NUw84xTded_!!6000000001574-55-tps-1939-1199.svg" />
+      <img
+        src="//img.alicdn.com/imgextra/i3/O1CN01iEwHrP1NUw84xTded_!!6000000001574-55-tps-1939-1199.svg"
+        alt="Formily 内核"
+      />
     </a>
   </Section>
 )
@@ -125,7 +131,10 @@ export default () => (
     titleStyle={{ paddingBottom: 20, fontWeight: 'bold' }}
   >
     <QrCodeGroup>
-      <QrCode link="//img.alicdn.com/imgextra/i1/O1CN011zlc5b1uu1BDUpNg1_!!6000000006096-2-tps-978-1380.png" />
+      <QrCode
+        link="//img.alicdn.com/imgextra/i1/O1CN011zlc5b1uu1BDUpNg1_!!6000000006096-2-tps-978-1380.png"
+        alt="Formily 社区二维码"
+      />
     </QrCodeGroup>
   </Section>
 )

--- a/docs/site/QrCode.tsx
+++ b/docs/site/QrCode.tsx
@@ -4,6 +4,7 @@ import './QrCode.less'
 export interface IQrCodeProps {
   title?: React.ReactNode
   link?: string
+  alt?: string
 }
 
 export const QrCode: React.FC<React.PropsWithChildren<IQrCodeProps>> = (
@@ -15,7 +16,7 @@ export const QrCode: React.FC<React.PropsWithChildren<IQrCodeProps>> = (
         <div className="qrcode-title-content">{props.title}</div>
       </div>
       <div className="qrcode-content">
-        <img src={props.link} />
+        <img src={props.link} alt={props.alt} />
       </div>
     </div>
   )


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

### Summary
This PR fixes accessibility violations by adding descriptive alt attributes to all images that were missing them.

### Problem
When running [IBM Accessibility Checker](https://github.com/IBMa/equal-access) (Version 4.0.9) on the [homepage](https://v2.formilyjs.org/), the IBM Equal Access Accessibility Checker identified QR-code images without alt text, which creates barriers for users relying on screen readers.

<img width="2560" height="920" alt="image" src="https://github.com/user-attachments/assets/c2ffc6c8-42e1-4b0a-8649-fc4c338fefcc" />

**Why is this important?**
When an image contains important information, providing a text alternative makes the same information accessible through assistive technologies, such as a Braille display. When an image is decorative or redundant, providing correct markup allows assistive technologies to ignore or not repeat the information.

### Solution

Added meaningful alt text to images in both English (`index.md`) and Chinese (`index.zh-CN.md`) documentation
Updated the `QrCode` component to accept an `alt` prop and pass it to the underlying `<img>` element
Used descriptive alt text that conveys the purpose/content of each image:

- "Formily Form Builder" / "Formily 表单设计器"
- "Formily Core" / "Formily 内核"
- "Formily Community QR Code" / "Formily 社区二维码"

### Testing

- Verified alt text appears correctly in the rendered HTML
- Confirmed IBM Equal Access Checker no longer reports violations for these images

Fix Before:
<img width="1879" height="828" alt="image" src="https://github.com/user-attachments/assets/255d0f65-7854-4198-a2c8-6d4016f547a5" />

Fix After:
<img width="1880" height="912" alt="image" src="https://github.com/user-attachments/assets/846f23dd-5d88-49f5-89d1-669d914d8aea" />

<img width="1869" height="922" alt="image" src="https://github.com/user-attachments/assets/1d488ab1-f5cc-4bc9-aea8-f0a3a724c33d" />


### Impact
This change improves accessibility compliance and ensures all users, including those using assistive technologies, can understand the content and purpose of images on the site.

- The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.
