### PR TITLE
feat(shared): 支持clone函数和dayjs对象的克隆

### DIFF
--- a/packages/shared/src/__tests__/index.spec.ts
+++ b/packages/shared/src/__tests__/index.spec.ts
@@ -1,4 +1,5 @@
 import moment from 'moment'
+import dayjs from 'dayjs'
 import { Map as ImmutableMap } from 'immutable'
 import { isEqual } from '../compare'
 import {
@@ -374,6 +375,8 @@ describe('clone and compare', () => {
     expect(clone(regexp) === regexp).toBeTruthy()
     const promise = Promise.resolve(1)
     expect(clone(promise) === promise).toBeTruthy()
+    const day = dayjs()
+    expect(clone(day).toISOString() === day.toISOString()).toBeTruthy()
   })
 
   test('shallowClone', () => {

--- a/packages/shared/src/clone.ts
+++ b/packages/shared/src/clone.ts
@@ -13,6 +13,9 @@ export const shallowClone = (values: any) => {
     if (values['_isAMomentObject']) {
       return values
     }
+
+    // >= dayjs@1.11.10 has `$isDayjsObject` check logic
+    // following the `moment` convention, return the original object directly
     if (values['$isDayjsObject']) {
       return values
     }
@@ -22,6 +25,9 @@ export const shallowClone = (values: any) => {
     if (isFn(values['toJS'])) {
       return values
     }
+    // < dayjs@1.11.10 has `clone` method, directly return a new object from `clone`, which won't cause logic issues.
+    // This check needs to be done before `toJSON` to avoid executing dayjs's `toJSON` method, which could cause type errors
+    // This logic check also applies to other similar objects, because the current method expects the return value to be the same as the input
     if (isFn(values['clone'])) {
       return values['clone']()
     }

--- a/packages/shared/src/clone.ts
+++ b/packages/shared/src/clone.ts
@@ -13,11 +13,17 @@ export const shallowClone = (values: any) => {
     if (values['_isAMomentObject']) {
       return values
     }
+    if (values['$isDayjsObject']) {
+      return values
+    }
     if (values['_isJSONSchemaObject']) {
       return values
     }
     if (isFn(values['toJS'])) {
       return values
+    }
+    if (isFn(values['clone'])) {
+      return values['clone']()
     }
     if (isFn(values['toJSON'])) {
       return values
@@ -48,11 +54,19 @@ export const clone = (values: any) => {
     if (values['_isAMomentObject']) {
       return values
     }
+
+    if (values['$isDayjsObject']) {
+      return values
+    }
+
     if (values['_isJSONSchemaObject']) {
       return values
     }
     if (isFn(values['toJS'])) {
       return values['toJS']()
+    }
+    if (isFn(values['clone'])) {
+      return values['clone']()
     }
     if (isFn(values['toJSON'])) {
       return values['toJSON']()


### PR DESCRIPTION
新增对含有clone方法对象和dayjs对象的克隆支持，完善clone函数功能并增加对应测试用例。
注: dayjs@1.11.10支持了标记位: `$isDayjsObject`, 更老的版本则使用clone函数

